### PR TITLE
fix(#15)!: allow tags in descriptive lists to have markup

### DIFF
--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -2336,21 +2336,27 @@ children:
             bullet: "- "
             counter: null
             checkbox: null
-            tag: "term1"
+            tag:
+              &a1
+              - type: "text"
+                value: "term1"
             end: 25
           - begin: 25
             indent: 0
             bullet: "- "
             counter: null
             checkbox: null
-            tag: "term 2"
+            tag:
+              &a2
+              - type: "text"
+                value: "term 2"
             end: 50
         children:
           - type: "item"
             indent: 0
             bullet: "- "
             checkbox: null
-            tag: "term1"
+            tag: *a1
             contentsBegin: 11
             contentsEnd: 25
             children:
@@ -2365,7 +2371,7 @@ children:
             indent: 0
             bullet: "- "
             checkbox: null
-            tag: "term 2"
+            tag: *a2
             contentsBegin: 37
             contentsEnd: 50
             children:
@@ -2480,6 +2486,224 @@ children:
                 children:
                   - type: "text"
                     value: "1. blah"
+`;
+
+exports[`org/parser list formatting in description list tags 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 389
+children:
+  - type: "section"
+    contentsBegin: 1
+    contentsEnd: 389
+    children:
+      - type: "plain-list"
+        affiliated: {}
+        indent: 0
+        listType: "descriptive"
+        contentsBegin: 1
+        contentsEnd: 389
+        structure:
+          - begin: 1
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a1
+              - type: "link"
+                format: "bracket"
+                linkType: "https"
+                rawLink: "https://example.com"
+                path: "//example.com"
+                contentsBegin: 26
+                contentsEnd: 33
+                children:
+                  - type: "text"
+                    value: "Example"
+            end: 52
+          - begin: 52
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a2
+              - type: "link"
+                format: "bracket"
+                linkType: "https"
+                rawLink: "https://github.com"
+                path: "//github.com"
+                contentsBegin: 76
+                contentsEnd: 82
+                children:
+                  - type: "text"
+                    value: "GitHub"
+            end: 128
+          - begin: 128
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a3
+              - type: "bold"
+                contentsBegin: 131
+                contentsEnd: 137
+                children:
+                  - type: "text"
+                    value: "Gitlab"
+            end: 164
+          - begin: 164
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a4
+              - type: "italic"
+                contentsBegin: 167
+                contentsEnd: 176
+                children:
+                  - type: "text"
+                    value: "Sourcehut"
+            end: 254
+          - begin: 254
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a5
+              - type: "italic"
+                contentsBegin: 257
+                contentsEnd: 265
+                children:
+                  - type: "text"
+                    value: "Codeberg"
+            end: 292
+          - begin: 292
+            indent: 0
+            bullet: "- "
+            counter: null
+            checkbox: null
+            tag:
+              &a6
+              - type: "italic"
+                contentsBegin: 295
+                contentsEnd: 320
+                children:
+                  - type: "bold"
+                    contentsBegin: 296
+                    contentsEnd: 319
+                    children:
+                      - type: "text"
+                        value: "self-hosting Git server"
+            end: 389
+        children:
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a1
+            contentsBegin: 39
+            contentsEnd: 52
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 39
+                contentsEnd: 52
+                children:
+                  - type: "text"
+                    value: "Hello there!\\n"
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a2
+            contentsBegin: 88
+            contentsEnd: 128
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 88
+                contentsEnd: 128
+                children:
+                  - type: "text"
+                    value: "This is GitHub, your hub for Git repos.\\n"
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a3
+            contentsBegin: 142
+            contentsEnd: 164
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 142
+                contentsEnd: 164
+                children:
+                  - type: "text"
+                    value: "Alternative to GitHub\\n"
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a4
+            contentsBegin: 181
+            contentsEnd: 254
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 181
+                contentsEnd: 254
+                children:
+                  - type: "text"
+                    value: "Another alternative to GitHub that primarily uses email-based
+                      workflows.\\n"
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a5
+            contentsBegin: 270
+            contentsEnd: 292
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 270
+                contentsEnd: 292
+                children:
+                  - type: "bold"
+                    contentsBegin: 271
+                    contentsEnd: 290
+                    children:
+                      - type: "text"
+                        value: "ANOTHER ALTERNATIVE"
+          - type: "item"
+            indent: 0
+            bullet: "- "
+            checkbox: null
+            tag: *a6
+            contentsBegin: 325
+            contentsEnd: 389
+            children:
+              - type: "paragraph"
+                affiliated: {}
+                contentsBegin: 325
+                contentsEnd: 389
+                children:
+                  - type: "italic"
+                    contentsBegin: 326
+                    contentsEnd: 387
+                    children:
+                      - type: "bold"
+                        contentsBegin: 327
+                        contentsEnd: 386
+                        children:
+                          - type: "text"
+                            value: "The ultimate Git solution for privacy-oriented individuals!"
 `;
 
 exports[`org/parser list list after paragraph 1`] = `

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -269,6 +269,19 @@ I have no :END:`
 - term 2 :: description 2`
     );
 
+    // See https://github.com/rasendubi/uniorg/issues/15
+    itParses(
+      'formatting in description list tags',
+      `
+- [[https://example.com][Example]] :: Hello there!
+- [[https://github.com][GitHub]] :: This is GitHub, your hub for Git repos.
+- *Gitlab* :: Alternative to GitHub
+- /Sourcehut/ :: Another alternative to GitHub that primarily uses email-based workflows.
+- /Codeberg/ :: *ANOTHER ALTERNATIVE*
+- /*self-hosting Git server*/ :: /*The ultimate Git solution for privacy-oriented individuals!*/
+`
+    );
+
     itParses(
       'list after paragraph',
       `hello

--- a/packages/uniorg-parse/src/utils.ts
+++ b/packages/uniorg-parse/src/utils.ts
@@ -223,7 +223,7 @@ export function itemRe(): RegExp {
 /// - checkbox
 /// - tag (description tag)
 export function fullItemRe(): RegExp {
-  return /^(?<indent>[ \t]*)(?<bullet>(?:[-+*]|(?:[0-9]+|[A-Za-z])[.)])(?:[ \t]+|$))(?:\[@(?:start:)?(?<counter>[0-9]+|[A-Za-z])\][ \t]*)?(?:(?<checkbox>\[[ X-]\])(?:[ \t]+|$))?(?:(?<tag>.*)[ \t]+::(?:[ \t]+|$))?/im;
+  return /^(?<indent>[ \t]*)(?<bullet>(?:[-+*]|(?:[0-9]+|[A-Za-z])[.)])(?:[ \t]+|$))(?<counter_group>\[@(?:start:)?(?<counter>[0-9]+|[A-Za-z])\][ \t]*)?(?<checkbox_group>(?<checkbox>\[[ X-]\])(?:[ \t]+|$))?(?:(?<tag>.*)[ \t]+::(?:[ \t]+|$))?/im;
 }
 
 export function listEndRe(): RegExp {

--- a/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
+++ b/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
@@ -50,6 +50,37 @@ exports[`org/org-to-hast description list 1`] = `
 
 `;
 
+exports[`org/org-to-hast description list with complex tags 1`] = `
+
+<dl>
+  <dt><a href="https://example.com">Example</a></dt>
+  <dd>
+    <p>Hello there!</p>
+  </dd>
+  <dt><a href="https://github.com">GitHub</a></dt>
+  <dd>
+    <p>This is GitHub, your hub for Git repos.</p>
+  </dd>
+  <dt><strong>Gitlab</strong></dt>
+  <dd>
+    <p>Alternative to GitHub</p>
+  </dd>
+  <dt><em>Sourcehut</em></dt>
+  <dd>
+    <p>Another alternative to GitHub that primarily uses email-based workflows.</p>
+  </dd>
+  <dt><em>Codeberg</em></dt>
+  <dd>
+    <p><strong>ANOTHER ALTERNATIVE</strong></p>
+  </dd>
+  <dt><em><strong>self-hosting Git server</strong></em></dt>
+  <dd>
+    <p><em><strong>The ultimate Git solution for privacy-oriented individuals!</strong></em></p>
+  </dd>
+</dl>
+
+`;
+
 exports[`org/org-to-hast diary sexp 1`] = ``;
 
 exports[`org/org-to-hast do not double-escape urls 1`] = `

--- a/packages/uniorg-rehype/src/org-to-hast.spec.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.spec.ts
@@ -123,6 +123,19 @@ hello /there/
 - term 2 :: description 2`
   );
 
+  // See https://github.com/rasendubi/uniorg/issues/15
+  hastTest(
+    'description list with complex tags',
+    `
+- [[https://example.com][Example]] :: Hello there!
+- [[https://github.com][GitHub]] :: This is GitHub, your hub for Git repos.
+- *Gitlab* :: Alternative to GitHub
+- /Sourcehut/ :: Another alternative to GitHub that primarily uses email-based workflows.
+- /Codeberg/ :: *ANOTHER ALTERNATIVE*
+- /*self-hosting Git server*/ :: /*The ultimate Git solution for privacy-oriented individuals!*/
+`
+  );
+
   hastTest('link', `https://example.com`);
 
   hastTest('link mixed with text', `hello http://example.com blah`);

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -168,8 +168,8 @@ export function orgToHast(
       case 'item':
         if (org.tag !== null) {
           return [
-            h(org, 'dt', {}, org.tag),
-            h(org, 'dd', toHast(org.children)),
+            h(org, 'dt', {}, toHast(org.tag)),
+            h(org, 'dd', {}, toHast(org.children)),
           ];
         } else {
           return h(org, 'li', {}, toHast(org.children));

--- a/packages/uniorg/src/index.ts
+++ b/packages/uniorg/src/index.ts
@@ -191,18 +191,19 @@ export interface List extends GreaterElement {
 
 export type ListStructureItem = {
   begin: number;
+  end: number;
   indent: number;
   bullet: string;
   counter: string | null;
   checkbox: string | null;
-  tag: string | null;
-  end: number;
+  tag: ObjectType[] | null;
 };
 
 export interface Item extends GreaterElement {
   type: 'item';
   indent: number;
-  tag: string | null;
+  tag: ObjectType[] | null;
+  // TODO: add checkbox?
 }
 
 export interface SrcBlock extends Node, WithAffiliatedKeywords {


### PR DESCRIPTION
Parse objects inside list tags. This is consistent with org-element.el and org-html-export.

BREAKING CHANGE: Item.tag is now a list of Objects, not a string.