### PR TITLE
feat(uniorg-rehype): footnote serialization

### DIFF
--- a/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
+++ b/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
@@ -145,6 +145,38 @@ exports[`org/org-to-hast fixed-width 1`] = `
 
 `;
 
+exports[`org/org-to-hast footnote-definition 1`] = `
+
+<p>
+  Some text with a footnote.<sup><a href="#fn.1" class="footnote-reference footnum" id="fnr.1"></a></sup>
+  Another footnote<sup><a href="#fn.2" class="footnote-reference footnum" id="fnr.2"></a></sup>
+</p>
+<h1>Footnotes</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1">1</a></sup>
+  <div class="footdef">
+    <p>A very important footnote.</p>
+  </div>
+</div>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.2" href="#fnr.2">2</a></sup>
+  <div class="footdef">
+    <p>Another stellar footnote.</p>
+  </div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnote-reference 1`] = `
+
+<p>Some text with a footnote.<sup><a href="#fn.1" class="footnote-reference footnum" id="fnr.1"></a></sup></p>
+<h1>Footnotes</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1">1</a></sup>
+  <div class="footdef">
+    <p>A very important footnote.</p>
+  </div>
+</div>
+
+`;
+
 exports[`org/org-to-hast headline 1`] = `
 
 <h1>hi</h1>

--- a/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
+++ b/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
@@ -145,33 +145,101 @@ exports[`org/org-to-hast fixed-width 1`] = `
 
 `;
 
-exports[`org/org-to-hast footnote-definition 1`] = `
+exports[`org/org-to-hast footnotes anonymous inline footnote 1`] = `
+
+<p>footnotes<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">inline footnote definition</div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnotes does not emit unreferenced footnotes 1`] = `
+
+<p>footnote<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">
+    <p>hello</p>
+  </div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnotes footnote-definition 1`] = `
 
 <p>
-  Some text with a footnote.<sup><a href="#fn.1" class="footnote-reference footnum" id="fnr.1"></a></sup>
-  Another footnote<sup><a href="#fn.2" class="footnote-reference footnum" id="fnr.2"></a></sup>
+  Some text with a footnote.<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup>
+  Another footnote <sup><a href="#fn.2" class="footref" id="fnr.2" role="doc-backlink">2</a></sup>
 </p>
-<h1>Footnotes</h1>
-<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1">1</a></sup>
-  <div class="footdef">
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">
     <p>A very important footnote.</p>
   </div>
 </div>
-<div class="footnote-definition"><sup><a class="footnum" id="fn.2" href="#fnr.2">2</a></sup>
-  <div class="footdef">
+<div class="footnote-definition"><sup><a class="footnum" id="fn.2" href="#fnr.2" role="doc-backlink">2</a></sup>
+  <div class="footdef" role="doc-footnote">
     <p>Another stellar footnote.</p>
   </div>
 </div>
 
 `;
 
-exports[`org/org-to-hast footnote-reference 1`] = `
+exports[`org/org-to-hast footnotes footnote-reference 1`] = `
 
-<p>Some text with a footnote.<sup><a href="#fn.1" class="footnote-reference footnum" id="fnr.1"></a></sup></p>
-<h1>Footnotes</h1>
-<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1">1</a></sup>
-  <div class="footdef">
+<p>Some text with a footnote.<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">
     <p>A very important footnote.</p>
+  </div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnotes handles missing footnotes 1`] = `
+
+<p>footnote<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+
+`;
+
+exports[`org/org-to-hast footnotes inline footnote 1`] = `
+
+<p>some text<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">footnote definition</div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnotes inline footnote 2`] = `
+
+<p>footnotes<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup></p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">inline footnote definition</div>
+</div>
+
+`;
+
+exports[`org/org-to-hast footnotes maintains footnotes order 1`] = `
+
+<p>
+  footnote 2<sup><a href="#fn.1" class="footref" id="fnr.1" role="doc-backlink">1</a></sup>
+  footnote 1<sup><a href="#fn.2" class="footref" id="fnr.2" role="doc-backlink">2</a></sup>
+</p>
+<h1>Footnotes:</h1>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.1" href="#fnr.1" role="doc-backlink">1</a></sup>
+  <div class="footdef" role="doc-footnote">
+    <p>first footnote</p>
+  </div>
+</div>
+<div class="footnote-definition"><sup><a class="footnum" id="fn.2" href="#fnr.2" role="doc-backlink">2</a></sup>
+  <div class="footdef" role="doc-footnote">
+    <p>second footnote</p>
   </div>
 </div>
 

--- a/packages/uniorg-rehype/src/org-to-hast.spec.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.spec.ts
@@ -369,6 +369,24 @@ some text
   );
 
   hastTest(
+    'footnote-reference',
+    `Some text with a footnote.[fn:1]
+  
+* Footnotes
+[fn:1] A very important footnote.`
+  );
+
+  hastTest(
+    'footnote-definition',
+    `Some text with a footnote.[fn:1]
+Another footnote [fn:2]    
+  
+* Footnotes
+[fn:1] A very important footnote.
+[fn:2] Another stellar footnote.`
+  );
+
+  hastTest(
     'latex-fragment',
     `If $a^2=b$ and \\( b=2 \\), then the solution must be
 either $$ a=+\\sqrt{2} $$ or \\[ a=-\\sqrt{2} \\].`

--- a/packages/uniorg-rehype/src/org-to-hast.spec.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.spec.ts
@@ -368,23 +368,55 @@ some text
     `%%(diary-anniversary 10 31 1948) Arthur's birthday (%d years old)`
   );
 
-  hastTest(
-    'footnote-reference',
-    `Some text with a footnote.[fn:1]
+  describe('footnotes', () => {
+    hastTest(
+      'footnote-reference',
+      `Some text with a footnote.[fn:1]
   
-* Footnotes
 [fn:1] A very important footnote.`
-  );
+    );
 
-  hastTest(
-    'footnote-definition',
-    `Some text with a footnote.[fn:1]
+    hastTest(
+      'footnote-definition',
+      `Some text with a footnote.[fn:1]
 Another footnote [fn:2]    
   
-* Footnotes
 [fn:1] A very important footnote.
 [fn:2] Another stellar footnote.`
-  );
+    );
+
+    hastTest('inline footnote', 'some text[fn:1: footnote definition]');
+
+    hastTest(
+      'maintains footnotes order',
+      // Note that footnotes are emmitted in order of reference
+      `footnote 2[fn:2]
+footnote 1[fn:1]
+
+[fn:1] second footnote
+[fn:2] first footnote`
+    );
+
+    hastTest(
+      'does not emit unreferenced footnotes',
+      `footnote[fn:1]
+
+[fn:1] hello
+[fn:2] unreferenced`
+    );
+
+    hastTest('handles missing footnotes', 'footnote[fn:missing]');
+
+    hastTest(
+      'inline footnote',
+      'footnotes[fn:label: inline footnote definition]'
+    );
+
+    hastTest(
+      'anonymous inline footnote',
+      'footnotes[fn:: inline footnote definition]'
+    );
+  });
 
   hastTest(
     'latex-fragment',

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -243,9 +243,41 @@ export function orgToHast(
       case 'diary-sexp':
         return null;
       case 'footnote-reference':
+        return h(
+          null,
+          'sup',
+          {},
+          h(
+            org,
+            'a',
+            {
+              href: `#fn.${org.label}`,
+              className: ['footnote-reference', 'footnum'],
+              id: `fnr.${org.label}`,
+            },
+            toHast(org.children)
+          )
+        );
       case 'footnote-definition':
         // TODO: serialize footnotes and footnote definitions.
-        return null;
+        return h(org, 'div', { className: 'footnote-definition' }, [
+          h(
+            null,
+            'sup',
+            {},
+            h(
+              null,
+              'a',
+              {
+                className: 'footnum',
+                id: `fn.${org.label}`,
+                href: `#fnr.${org.label}`,
+              },
+              org.label
+            )
+          ),
+          h(org, '', { className: 'footdef' }, toHast(org.children)),
+        ]);
       case 'paragraph':
         return h(org, 'p', {}, toHast(org.children));
       case 'bold':

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -1,7 +1,14 @@
 import u from 'unist-builder';
 import hast from 'hastscript';
 import { Properties, Node, Element } from 'hast';
-import { OrgNode, OrgData, TableRow, Headline } from 'uniorg';
+import {
+  OrgNode,
+  OrgData,
+  TableRow,
+  Headline,
+  FootnoteReference,
+  FootnoteDefinition,
+} from 'uniorg';
 
 type Hast = any;
 
@@ -11,6 +18,20 @@ export interface OrgToHastOptions {
    * Whether to wrap org sections into <section>.
    */
   useSections: boolean;
+  /**
+   * A function to wrap footnotes. First argument of the function is
+   * an array of all footnote definitions and the function should
+   * return a new Hast node to be appended to the document.
+   *
+   * Roughly corresponds to `org-html-footnotes-section`.
+   *
+   * Default is:
+   * ```
+   * <h1>Footnotes:</h1>
+   * {...footnotes}
+   * ```
+   */
+  footnotesSection: (footnotes: Node[]) => Node[];
 }
 
 const defaultOptions: OrgToHastOptions = {
@@ -30,6 +51,10 @@ const defaultOptions: OrgToHastOptions = {
     'svg',
   ],
   useSections: false,
+  footnotesSection: (footnotes) => [
+    h(null, 'h1', {}, 'Footnotes:'),
+    ...footnotes,
+  ],
 };
 
 // `org-html-html5-elements`
@@ -74,11 +99,24 @@ function h(
   return element;
 }
 
+type Ctx = {
+  // Labels of footnotes as they occur in footnote-reference.
+  footnotesOrder: Array<string | number>;
+  // map of: label -> footnote div
+  footnotes: Record<string, FootnoteDefinition | FootnoteReference>;
+};
+
 export function orgToHast(
   org: OrgData,
   opts: Partial<OrgToHastOptions> = {}
 ): Hast {
   const options = { ...defaultOptions, ...opts };
+
+  const ctx: Ctx = {
+    footnotesOrder: [],
+    footnotes: {},
+  };
+
   return toHast(org);
 
   function toHast(node: any): Hast {
@@ -98,7 +136,54 @@ export function orgToHast(
 
     switch (org.type) {
       case 'org-data':
-        return { type: 'root', children: toHast(org.children) };
+        const children = toHast(org.children);
+
+        const footnotes = ctx.footnotesOrder
+          .map((name, i) => {
+            const def = ctx.footnotes[name];
+
+            if (!def) {
+              // missing footnote definition
+              return null;
+            }
+
+            return h(org, 'div', { className: 'footnote-definition' }, [
+              h(
+                null,
+                'sup',
+                {},
+                h(
+                  null,
+                  'a',
+                  {
+                    className: 'footnum',
+                    id: `fn.${i + 1}`,
+                    href: `#fnr.${i + 1}`,
+                    role: 'doc-backlink',
+                  },
+                  String(i + 1)
+                )
+              ),
+              h(
+                org,
+                'div',
+                { className: 'footdef', role: 'doc-footnote' },
+                toHast(def.children)
+              ),
+            ]);
+          })
+          .filter((x) => x !== null) as Node[];
+        if (footnotes.length !== 0) {
+          if (opts.useSections) {
+            children.push(
+              h(null, 'section', {}, options.footnotesSection(footnotes))
+            );
+          } else {
+            children.push(...options.footnotesSection(footnotes));
+          }
+        }
+
+        return { type: 'root', children };
       case 'section': {
         const headline = org.children[0] as Headline;
         // TODO: support other options that prevent export:
@@ -243,6 +328,28 @@ export function orgToHast(
       case 'diary-sexp':
         return null;
       case 'footnote-reference':
+        // index of footnote in ctx.footnotesOrder
+        let idx = 0;
+        let id = '';
+        if (org.footnoteType === 'inline') {
+          idx = ctx.footnotesOrder.length;
+          ctx.footnotesOrder.push(idx);
+          ctx.footnotes[idx] = org;
+          id = `fnr.${idx + 1}`;
+        } else if (org.footnoteType === 'standard') {
+          idx = ctx.footnotesOrder.findIndex((label) => label === org.label);
+          if (idx === -1) {
+            idx = ctx.footnotesOrder.length;
+            ctx.footnotesOrder.push(org.label);
+            id = `fnr.${idx + 1}`;
+            // We do not set id in the else branch because that’s a
+            // second reference to this footnote—another reference
+            // with this id exists.
+          }
+        } else {
+          throw new Error(`unknown footnoteType: ${org.footnoteType}`);
+        }
+
         return h(
           null,
           'sup',
@@ -251,33 +358,17 @@ export function orgToHast(
             org,
             'a',
             {
-              href: `#fn.${org.label}`,
-              className: ['footnote-reference', 'footnum'],
-              id: `fnr.${org.label}`,
+              href: `#fn.${idx + 1}`,
+              className: ['footref'],
+              id,
+              role: 'doc-backlink',
             },
-            toHast(org.children)
+            String(idx + 1)
           )
         );
       case 'footnote-definition':
-        // TODO: serialize footnotes and footnote definitions.
-        return h(org, 'div', { className: 'footnote-definition' }, [
-          h(
-            null,
-            'sup',
-            {},
-            h(
-              null,
-              'a',
-              {
-                className: 'footnum',
-                id: `fn.${org.label}`,
-                href: `#fnr.${org.label}`,
-              },
-              org.label
-            )
-          ),
-          h(org, '', { className: 'footdef' }, toHast(org.children)),
-        ]);
+        ctx.footnotes[org.label] = org;
+        return null;
       case 'paragraph':
         return h(org, 'p', {}, toHast(org.children));
       case 'bold':


### PR DESCRIPTION
This works, but there are two things I'm not completely happy with:

1. The footnote-definition number is not inline by default with the string of text. ox-html just solves this with css, which is fine I think.
2. I saw that the FootnoteReference type has "inline" and "standard" footnote types. I don't really know when the "standard" footnote would happen, so I have not dealt with it yet.

Let me know what you think!