### PR TITLE
fix: handle single asterisk on a line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,32 +18,32 @@
       }
     },
     "examples/example": {
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "rehype-stringify": "9.0.3",
         "unified": "10.1.2",
         "unified-stream": "2.0.0",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8"
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0"
       }
     },
     "examples/extract-keywords-example": {
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ci": "^2.1.1",
         "rehype-stringify": "9.0.3",
         "to-vfile": "7.2.3",
         "unified": "10.1.2",
-        "uniorg-extract-keywords": "^0.4.5",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8"
+        "uniorg-extract-keywords": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0"
       }
     },
     "examples/next-blog-starter": {
       "name": "blog-starter",
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "2.2.6",
@@ -63,7 +63,7 @@
       }
     },
     "examples/org-braindump": {
-      "version": "0.4.8",
+      "version": "0.5.0",
       "dependencies": {
         "next": "^12.0.5",
         "react": "17.0.2",
@@ -15247,19 +15247,19 @@
       }
     },
     "packages/orgast-util-to-string": {
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/jest": "27.4.1",
         "@types/unist": "2.0.6",
         "jest": "27.5.1",
         "typescript": "4.6.3",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5"
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0"
       }
     },
     "packages/orgast-util-visit-ids": {
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "unist-util-visit-parents": "5.1.0"
@@ -15269,12 +15269,12 @@
         "@types/unist": "2.0.6",
         "jest": "27.5.1",
         "typescript": "4.6.3",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5"
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0"
       }
     },
     "packages/uniorg": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/unist": "2.0.6",
@@ -15282,7 +15282,7 @@
       }
     },
     "packages/uniorg-attach": {
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "unist-util-visit-parents": "5.1.0"
@@ -15292,14 +15292,14 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "vfile": "5.3.2",
         "yaml": "^2.0.0"
       }
     },
     "packages/uniorg-extract-keywords": {
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "unist-util-visit": "4.1.0"
@@ -15310,13 +15310,13 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "vfile": "^5.3.2"
       }
     },
     "packages/uniorg-parse": {
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "unist-builder": "3.0.0",
@@ -15330,12 +15330,12 @@
         "ts-jest": "^27.1.4",
         "typescript": "4.6.3",
         "unified": "^10.1.2",
-        "uniorg": "^0.4.0",
+        "uniorg": "^0.5.0",
         "yaml": "^2.0.0"
       }
     },
     "packages/uniorg-rehype": {
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "hastscript": "7.0.2",
@@ -15351,16 +15351,16 @@
         "ts-jest": "^27.1.4",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5"
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0"
       }
     },
     "packages/uniorg-slug": {
-      "version": "0.4.8",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "github-slugger": "^1.3.0",
-        "orgast-util-to-string": "^0.4.5",
+        "orgast-util-to-string": "^0.5.0",
         "unist-util-visit": "4.1.0"
       },
       "devDependencies": {
@@ -15371,15 +15371,15 @@
         "rehype-stringify": "9.0.3",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0",
         "unist-util-find": "^1.0.2",
         "vfile": "5.3.2"
       }
     },
     "packages/uniorg-stringify": {
-      "version": "0.4.9",
+      "version": "0.5.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/jest": "27.4.1",
@@ -15387,8 +15387,8 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "vfile": "5.3.2"
       }
     }
@@ -19564,8 +19564,8 @@
         "rehype-stringify": "9.0.3",
         "unified": "10.1.2",
         "unified-stream": "2.0.0",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8"
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0"
       }
     },
     "execa": {
@@ -19642,9 +19642,9 @@
         "rehype-stringify": "9.0.3",
         "to-vfile": "7.2.3",
         "unified": "10.1.2",
-        "uniorg-extract-keywords": "^0.4.5",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8"
+        "uniorg-extract-keywords": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0"
       }
     },
     "extsprintf": {
@@ -23134,8 +23134,8 @@
         "@types/unist": "2.0.6",
         "jest": "27.5.1",
         "typescript": "4.6.3",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5"
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0"
       }
     },
     "orgast-util-visit-ids": {
@@ -23145,8 +23145,8 @@
         "@types/unist": "2.0.6",
         "jest": "27.5.1",
         "typescript": "4.6.3",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "unist-util-visit-parents": "5.1.0"
       }
     },
@@ -26427,8 +26427,8 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "unist-util-visit-parents": "5.1.0",
         "vfile": "5.3.2",
         "yaml": "^2.0.0"
@@ -26442,8 +26442,8 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "unist-util-visit": "4.1.0",
         "vfile": "^5.3.2"
       }
@@ -26457,7 +26457,7 @@
         "ts-jest": "^27.1.4",
         "typescript": "4.6.3",
         "unified": "^10.1.2",
-        "uniorg": "^0.4.0",
+        "uniorg": "^0.5.0",
         "unist-builder": "3.0.0",
         "vfile": "5.3.2",
         "vfile-location": "4.0.1",
@@ -26477,8 +26477,8 @@
         "ts-jest": "^27.1.4",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "unist-builder": "3.0.0"
       }
     },
@@ -26490,13 +26490,13 @@
         "@types/unist": "2.0.6",
         "github-slugger": "^1.3.0",
         "jest": "27.5.1",
-        "orgast-util-to-string": "^0.4.5",
+        "orgast-util-to-string": "^0.5.0",
         "rehype-stringify": "9.0.3",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
-        "uniorg-rehype": "^0.4.8",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
+        "uniorg-rehype": "^0.5.0",
         "unist-util-find": "^1.0.2",
         "unist-util-visit": "4.1.0",
         "vfile": "5.3.2"
@@ -26510,8 +26510,8 @@
         "jest": "27.5.1",
         "typescript": "4.6.3",
         "unified": "10.1.2",
-        "uniorg": "^0.4.0",
-        "uniorg-parse": "^0.4.5",
+        "uniorg": "^0.5.0",
+        "uniorg-parse": "^0.5.0",
         "vfile": "5.3.2"
       }
     },

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -3480,6 +3480,34 @@ children:
         value: "hi"
 `;
 
+exports[`org/parser single asterisk 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 18
+children:
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 0
+    contentsEnd: 5
+    children:
+      - type: "text"
+        value: "text\\n"
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 5
+    contentsEnd: 7
+    children:
+      - type: "text"
+        value: "*\\n"
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 8
+    contentsEnd: 18
+    children:
+      - type: "text"
+        value: "more text\\n"
+`;
+
 exports[`org/parser subscript after subscript 1`] = `
 type: "org-data"
 contentsBegin: 0

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -934,4 +934,14 @@ either $$ a=+\\sqrt{2} $$ or \\[ a=-\\sqrt{2} \\].`
   itParses('entity', `\\Agrave`);
 
   itParses('entity in parentheses', `(\\leq)`);
+
+  // See https://github.com/rasendubi/uniorg/issues/34
+  itParses(
+    'single asterisk',
+    `text
+*
+
+more text
+`
+  );
 });

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -1289,7 +1289,8 @@ class Parser {
 
       const m = this.r.match(this.re.listItemRe());
       if (m) {
-        const indent = m.groups!.indent.length;
+        const indent =
+          (m.groups!.indent1?.length || 0) + (m.groups!.indent2?.length || 0);
         // end previous siblings
         while (items.length && items[items.length - 1].indent >= indent) {
           const item = items.pop()!;

--- a/packages/uniorg-parse/src/utils.ts
+++ b/packages/uniorg-parse/src/utils.ts
@@ -59,9 +59,10 @@ export class OrgRegexUtils {
     );
   }
 
+  // see (org-item-re)
   public listItemRe(): RegExp {
     return new RegExp(
-      `^(?<indent> *)(\\*|-|\\+|\\d+\\.|\\d+\\)|\\w\\.|\\w\\))( |\\n)`
+      `^((?<indent1>[ \\t]+)\\*|(?<indent2>[ \\t]*)(-|\\+|\\d+\\.|\\d+\\)|\\w\\.|\\w\\)))([ \\t]|\\n)`
     );
   }
 
@@ -71,6 +72,7 @@ export class OrgRegexUtils {
   /// - counter
   /// - checkbox
   /// - tag (description tag)
+  // see org-list-full-item-re
   public fullListItemRe(): RegExp {
     return /^(?<indent>[ \t]*)(?<bullet>(?:[-+*]|(?:[0-9]+|[A-Za-z])[.)])(?:[ \t]+|$))(?<counter_group>\[@(?:start:)?(?<counter>[0-9]+|[A-Za-z])\][ \t]*)?(?<checkbox_group>(?<checkbox>\[[ X-]\])(?:[ \t]+|$))?(?:(?<tag>.*?)[ \t]+::(?:[ \t]+|$))?/im;
   }


### PR DESCRIPTION
The issue is caused by list item regex capturing *-items on start of the line. Fixed this by requiring at least one space before * in list (well, just copying org-item-re from org-element.el)

fixes #34