### PR TITLE
fix(#36): add type:module to uniorg

### DIFF
--- a/packages/uniorg/package.json
+++ b/packages/uniorg/package.json
@@ -1,6 +1,7 @@
 {
   "name": "uniorg",
-  "version": "0.5.0",
+  "version": "0.5.1",
+  "type": "module",
   "description": "uniorg type definitions",
   "keywords": [
     "uniorg",

--- a/packages/uniorg/package.json
+++ b/packages/uniorg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniorg",
-  "version": "0.5.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "uniorg type definitions",
   "keywords": [


### PR DESCRIPTION
Fix #36 by making all bundlers recognize uniorg as an ESM module.

This will probably also happen with Next.js, so good to catch it early. 