### PR TITLE
feat: statistics-cookie

### DIFF
--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -1241,6 +1241,189 @@ children:
             value: " title"
 `;
 
+exports[`org/parser headline complex headline with defined fraction statistics-cookie 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 61
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 61
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: "TODO"
+        priority: "A"
+        commented: false
+        rawValue: "[1/2] COMMENT headline /italic/ title"
+        tags:
+          - "some"
+          - "tags"
+        contentsBegin: 12
+        contentsEnd: 49
+        children:
+          - type: "statistics-cookie"
+            begin: 12
+            end: 17
+            value: "[1/2]"
+          - type: "text"
+            value: "COMMENT headline "
+          - type: "italic"
+            contentsBegin: 36
+            contentsEnd: 42
+            children:
+              - type: "text"
+                value: "italic"
+          - type: "text"
+            value: " title"
+`;
+
+exports[`org/parser headline complex headline with defined fraction statistics-cookie 2`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 61
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 61
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: "TODO"
+        priority: "A"
+        commented: true
+        rawValue: "headline /italic/ title :some:tags: [1/3]"
+        tags: []
+        contentsBegin: 20
+        contentsEnd: 61
+        children:
+          - type: "text"
+            value: "headline "
+          - type: "italic"
+            contentsBegin: 30
+            contentsEnd: 36
+            children:
+              - type: "text"
+                value: "italic"
+          - type: "text"
+            value: " title :some:tags: "
+          - type: "statistics-cookie"
+            begin: 56
+            end: 61
+            value: "[1/3]"
+`;
+
+exports[`org/parser headline complex headline with defined percentage statistics-cookie 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 61
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 61
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: "TODO"
+        priority: "A"
+        commented: false
+        rawValue: "[50%] COMMENT headline /italic/ title"
+        tags:
+          - "some"
+          - "tags"
+        contentsBegin: 12
+        contentsEnd: 49
+        children:
+          - type: "statistics-cookie"
+            begin: 12
+            end: 17
+            value: "[50%]"
+          - type: "text"
+            value: "COMMENT headline "
+          - type: "italic"
+            contentsBegin: 36
+            contentsEnd: 42
+            children:
+              - type: "text"
+                value: "italic"
+          - type: "text"
+            value: " title"
+`;
+
+exports[`org/parser headline complex headline with empty fraction statistics-cookie 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 59
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 59
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: "TODO"
+        priority: "A"
+        commented: false
+        rawValue: "[/] COMMENT headline /italic/ title"
+        tags:
+          - "some"
+          - "tags"
+        contentsBegin: 12
+        contentsEnd: 47
+        children:
+          - type: "statistics-cookie"
+            begin: 12
+            end: 15
+            value: "[/]"
+          - type: "text"
+            value: "COMMENT headline "
+          - type: "italic"
+            contentsBegin: 34
+            contentsEnd: 40
+            children:
+              - type: "text"
+                value: "italic"
+          - type: "text"
+            value: " title"
+`;
+
+exports[`org/parser headline complex headline with empty percentage statistics-cookie 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 59
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 59
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: "TODO"
+        priority: "A"
+        commented: false
+        rawValue: "[%] COMMENT headline /italic/ title"
+        tags:
+          - "some"
+          - "tags"
+        contentsBegin: 12
+        contentsEnd: 47
+        children:
+          - type: "statistics-cookie"
+            begin: 12
+            end: 15
+            value: "[%]"
+          - type: "text"
+            value: "COMMENT headline "
+          - type: "italic"
+            contentsBegin: 34
+            contentsEnd: 40
+            children:
+              - type: "text"
+                value: "italic"
+          - type: "text"
+            value: " title"
+`;
+
 exports[`org/parser headline custom todo keywords 1`] = `
 type: "org-data"
 contentsBegin: 0
@@ -1262,6 +1445,33 @@ children:
         children:
           - type: "text"
             value: "my custom todo keyword"
+`;
+
+exports[`org/parser headline headline starting with fraction statistics-cookie 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 19
+children:
+  - type: "section"
+    contentsBegin: 0
+    contentsEnd: 19
+    children:
+      - type: "headline"
+        level: 1
+        todoKeyword: null
+        priority: null
+        commented: false
+        rawValue: "[1/100] Something"
+        tags: []
+        contentsBegin: 2
+        contentsEnd: 19
+        children:
+          - type: "statistics-cookie"
+            begin: 2
+            end: 9
+            value: "[1/100]"
+          - type: "text"
+            value: "Something"
 `;
 
 exports[`org/parser headline multiple headlines 1`] = `

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -92,6 +92,36 @@ describe('org/parser', () => {
 
 * DONE Headline 2`
     );
+
+    itParses(
+      'headline starting with fraction statistics-cookie',
+      `* [1/100] Something`
+    );
+
+    itParses(
+      'complex headline with empty percentage statistics-cookie',
+      `* TODO [#A] [%] COMMENT headline /italic/ title :some:tags:`
+    );
+
+    itParses(
+      'complex headline with empty fraction statistics-cookie',
+      `* TODO [#A] [/] COMMENT headline /italic/ title :some:tags:`
+    );
+
+    itParses(
+      'complex headline with defined percentage statistics-cookie',
+      `* TODO [#A] [50%] COMMENT headline /italic/ title :some:tags:`
+    );
+
+    itParses(
+      'complex headline with defined fraction statistics-cookie',
+      `* TODO [#A] [1/2] COMMENT headline /italic/ title :some:tags:`
+    );
+
+    itParses(
+      'complex headline with defined fraction statistics-cookie',
+      `* TODO [#A] COMMENT headline /italic/ title :some:tags: [1/3]`
+    );
   });
 
   describe('section', () => {

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -22,6 +22,7 @@ import {
   Code,
   Verbatim,
   StrikeThrough,
+  StatisticsCookie,
   Timestamp,
   Planning,
   PropertyDrawer,
@@ -588,7 +589,11 @@ class Parser {
           if (ts) return ts;
           this.r.resetOffset(offset);
 
-          // TODO: statistics cookie
+          const cookie =
+            restriction.has('statistics-cookie') &&
+            this.parseStatisticsCookie();
+          if (cookie) return cookie;
+          this.r.resetOffset(offset);
         }
 
         break;
@@ -1484,6 +1489,16 @@ class Parser {
     const contentsEnd = contentsBegin + m[4].length;
     this.r.resetOffset(contentsEnd + 1);
     return u('strike-through', { contentsBegin, contentsEnd }, []);
+  }
+
+  private parseStatisticsCookie(): StatisticsCookie | null {
+    const m = this.r.lookingAt(/\[[0-9]*(\%|\/[0-9]*)\]/);
+    if (!m) return null;
+    const begin = this.r.offset() + m.index;
+    const end = begin + m[0].length;
+    const value = this.r.substring(begin, end);
+    this.r.resetOffset(end + 1);
+    return u('statistics-cookie', { begin, end, value });
   }
 
   private parseEntity(): Entity | null {

--- a/packages/uniorg/src/index.ts
+++ b/packages/uniorg/src/index.ts
@@ -60,6 +60,7 @@ export type ObjectType =
   | Code
   | Verbatim
   | StrikeThrough
+  | StatisticsCookie
   | Underline
   | Superscript
   | Subscript
@@ -292,6 +293,11 @@ export interface Verbatim extends Object {
 
 export interface StrikeThrough extends RecursiveObject {
   type: 'strike-through';
+}
+
+export interface StatisticsCookie extends Object {
+  type: 'statistics-cookie';
+  value: string;
 }
 
 export interface Underline extends RecursiveObject {


### PR DESCRIPTION
This PR provides a rudimentary implementation for parsing statistics-cookies https://orgmode.org/worg/dev/org-syntax.html#Statistics_Cookies.

I'm thinking about extending this such that `StatisticsCookie` has a `statistic` field of the types `null | PercentStat | FractionStat`. @rasendubi, does this fit within the vision of the project or do you consider this a concern that end-users should handle in their own application logic?