### PR TITLE
Adding className if heading is a todo

### DIFF
--- a/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
+++ b/packages/uniorg-rehype/src/__snapshots__/org-to-hast.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`org/org-to-hast comments 1`] = `
 
 exports[`org/org-to-hast complex headline 1`] = `
 
-<h1><span class="todo-keyword TODO">TODO</span> <span class="priority priority-A">[A]</span> headline <em>italic</em> title   <span class="tags"><span class="tag tag-some">some</span> <span class="tag tag-tags">tags</span></span></h1>
+<h1 class="todo-headline"><span class="todo-keyword TODO">TODO</span> <span class="priority priority-A">[A]</span> headline <em>italic</em> title   <span class="tags"><span class="tag tag-some">some</span> <span class="tag tag-tags">tags</span></span></h1>
 
 `;
 

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -258,7 +258,7 @@ export function orgToHast(
         return h(
           org,
           `h${org.level}`,
-          {},
+          {todo ? "todo-item" : ""},
           [todo, priority, ...toHast(org.children), tags].filter(
             (x) => x
           ) as Hast[]

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -258,7 +258,7 @@ export function orgToHast(
         return h(
           org,
           `h${org.level}`,
-          {todo ? "todo-item" : ""},
+          { className: todo ? 'todo-headline' : '' },
           [todo, priority, ...toHast(org.children), tags].filter(
             (x) => x
           ) as Hast[]

--- a/packages/uniorg-rehype/src/org-to-hast.ts
+++ b/packages/uniorg-rehype/src/org-to-hast.ts
@@ -258,7 +258,7 @@ export function orgToHast(
         return h(
           org,
           `h${org.level}`,
-          { className: todo ? 'todo-headline' : '' },
+          todo ? { className: 'todo-headline' } : {},
           [todo, priority, ...toHast(org.children), tags].filter(
             (x) => x
           ) as Hast[]


### PR DESCRIPTION
This conditionally adds a className of "todo-item" to headings which contain a TODO face. This will allow for better styling controls, as currently there isn't a way to selectively style headings that are TODO items separately from headings that are not TODO items. This should result in a familiar output compared to org-export, which does mark headings with TODO items with an additional class.