### PR TITLE
feat: begin/end ranges for primitive nodes

### DIFF
--- a/packages/uniorg-attach/src/__snapshots__/index.spec.ts.snap
+++ b/packages/uniorg-attach/src/__snapshots__/index.spec.ts.snap
@@ -20,8 +20,26 @@ children:
         children:
           - type: "text"
             value: "Other file"
+            position:
+              start:
+                line: 1
+                column: 20
+                offset: 19
+              end:
+                line: 1
+                column: 30
+                offset: 29
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 32
+            offset: 31
+          end:
+            line: 1
+            column: 33
+            offset: 32
       - type: "link"
         format: "plain"
         linkType: "https"
@@ -42,6 +60,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "ead7b7db-8aac-4b1f-893f-9e7f5ca6ea2c"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 57
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 63
@@ -67,6 +94,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "ead7b7db-8aac-4b1f-893f-9e7f5ca6ea2c"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 57
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 63
@@ -92,6 +128,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "20210922T144052.487159"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 42
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 48
@@ -117,6 +162,15 @@ children:
       - type: "node-property"
         key: "DIR"
         value: "attach"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 27
   - type: "section"
     contentsBegin: 33
     contentsEnd: 127
@@ -133,6 +187,15 @@ children:
         children:
           - type: "text"
             value: "Headline"
+            position:
+              start:
+                line: 4
+                column: 3
+                offset: 35
+              end:
+                line: 4
+                column: 11
+                offset: 43
       - type: "property-drawer"
         contentsBegin: 57
         contentsEnd: 101
@@ -140,6 +203,15 @@ children:
           - type: "node-property"
             key: "ID"
             value: "ead7b7db-8aac-4b1f-893f-9e7f5ca6ea2c"
+            position:
+              start:
+                line: 6
+                column: 1
+                offset: 57
+              end:
+                line: 7
+                column: 1
+                offset: 101
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 107
@@ -165,6 +237,15 @@ children:
       - type: "node-property"
         key: "DIR"
         value: "attach"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 27
   - type: "section"
     contentsBegin: 33
     contentsEnd: 64
@@ -181,6 +262,15 @@ children:
         children:
           - type: "text"
             value: "Headline"
+            position:
+              start:
+                line: 4
+                column: 3
+                offset: 35
+              end:
+                line: 4
+                column: 11
+                offset: 43
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 44
@@ -206,6 +296,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "ead7b7db-8aac-4b1f-893f-9e7f5ca6ea2c"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 57
   - type: "section"
     contentsBegin: 63
     contentsEnd: 94
@@ -222,6 +321,15 @@ children:
         children:
           - type: "text"
             value: "Headline"
+            position:
+              start:
+                line: 4
+                column: 3
+                offset: 65
+              end:
+                line: 4
+                column: 11
+                offset: 73
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 74
@@ -247,9 +355,27 @@ children:
       - type: "node-property"
         key: "ID"
         value: "hello-id"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 28
       - type: "node-property"
         key: "DIR"
         value: "/directory"
+        position:
+          start:
+            line: 3
+            column: 1
+            offset: 28
+          end:
+            line: 4
+            column: 1
+            offset: 46
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 52
@@ -275,6 +401,15 @@ children:
       - type: "node-property"
         key: "DIR"
         value: "/home/user/attachment"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 45
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 52
@@ -300,6 +435,15 @@ children:
       - type: "node-property"
         key: "DIR"
         value: "/home/user/attachment"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 45
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 52
@@ -325,6 +469,15 @@ children:
       - type: "node-property"
         key: "DIR"
         value: "./attachments"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 33
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 40
@@ -350,6 +503,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "ead7b7db-8aac-4b1f-893f-9e7f5ca6ea2c"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 57
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 63
@@ -384,6 +546,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 11
@@ -409,6 +580,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "hello"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 24
   - type: "section"
     contentsBegin: 30
     contentsEnd: 65
@@ -425,6 +605,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 4
+                column: 3
+                offset: 32
+              end:
+                line: 4
+                column: 11
+                offset: 40
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 41
@@ -459,6 +648,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "property-drawer"
         contentsBegin: 24
         contentsEnd: 35
@@ -466,6 +664,15 @@ children:
           - type: "node-property"
             key: "ID"
             value: "hello"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 24
+              end:
+                line: 4
+                column: 1
+                offset: 35
       - type: "section"
         contentsBegin: 41
         contentsEnd: 84
@@ -482,6 +689,15 @@ children:
             children:
               - type: "text"
                 value: "nested headline"
+                position:
+                  start:
+                    line: 5
+                    column: 4
+                    offset: 44
+                  end:
+                    line: 5
+                    column: 19
+                    offset: 59
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 60

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -33,13 +33,13 @@ children:
     value: ""
     position:
       start:
-        line: 3
+        line: 2
         column: 1
-        offset: 26
+        offset: 14
       end:
-        line: 3
+        line: 4
         column: 1
-        offset: 26
+        offset: 36
 `;
 
 exports[`org/parser affiliated keyword multiple keywords 1`] = `
@@ -137,13 +137,13 @@ children:
     value: "some paragraph\\n"
     position:
       start:
-        line: 3
+        line: 2
         column: 1
-        offset: 31
+        offset: 15
       end:
         line: 4
-        column: 1
-        offset: 46
+        column: 10
+        offset: 55
 `;
 
 exports[`org/parser affiliated keyword parsed keywords 1`] = `
@@ -207,13 +207,13 @@ children:
     value: "#+ escaped\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 16
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 28
+        column: 10
+        offset: 37
 `;
 
 exports[`org/parser blocks center block 1`] = `
@@ -255,13 +255,13 @@ children:
     value: ",,* two commas escaped\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 16
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 40
+        column: 10
+        offset: 49
 `;
 
 exports[`org/parser blocks comment block 1`] = `
@@ -294,13 +294,13 @@ children:
     value: "*a = 0;\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 14
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 23
+        column: 10
+        offset: 32
 `;
 
 exports[`org/parser blocks example block 1`] = `
@@ -313,13 +313,13 @@ children:
     value: "hi\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 16
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 19
+        column: 14
+        offset: 32
 `;
 
 exports[`org/parser blocks export block 1`] = `
@@ -333,13 +333,13 @@ children:
     value: "hi\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 15
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 18
+        column: 13
+        offset: 30
 `;
 
 exports[`org/parser blocks export block with backend 1`] = `
@@ -353,13 +353,13 @@ children:
     value: "hi\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 20
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 23
+        column: 13
+        offset: 35
 `;
 
 exports[`org/parser blocks fake block 1`] = `
@@ -482,13 +482,13 @@ children:
     value: ",# nont escaped\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 16
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 32
+        column: 10
+        offset: 41
 `;
 
 exports[`org/parser blocks headline escaper in src block 1`] = `
@@ -502,13 +502,13 @@ children:
     value: "* not a headline;\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 16
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 35
+        column: 10
+        offset: 44
 `;
 
 exports[`org/parser blocks incomplete block after paragraph 1`] = `
@@ -627,13 +627,13 @@ children:
     value: "hello\\n"
     position:
       start:
-        line: 2
+        line: 1
         column: 1
-        offset: 12
+        offset: 0
       end:
         line: 3
-        column: 1
-        offset: 18
+        column: 10
+        offset: 27
 `;
 
 exports[`org/parser blocks src in list 1`] = `
@@ -677,13 +677,13 @@ children:
             value: "  blah\\n"
             position:
               start:
-                line: 4
+                line: 3
                 column: 1
-                offset: 26
+                offset: 12
               end:
                 line: 5
-                column: 1
-                offset: 33
+                column: 12
+                offset: 44
 `;
 
 exports[`org/parser blocks verse block 1`] = `
@@ -736,8 +736,8 @@ children:
       position:
         start:
           line: 1
-          column: 8
-          offset: 7
+          column: 1
+          offset: 0
         end:
           line: 1
           column: 30
@@ -780,8 +780,8 @@ children:
       position:
         start:
           line: 1
-          column: 8
-          offset: 7
+          column: 1
+          offset: 0
         end:
           line: 1
           column: 54
@@ -795,8 +795,8 @@ children:
         offset: 0
       end:
         line: 1
-        column: 54
-        offset: 53
+        column: 63
+        offset: 62
 `;
 
 exports[`org/parser comments does not eat keyword 1`] = `
@@ -1219,12 +1219,12 @@ children:
         position:
           start:
             line: 1
-            column: 19
-            offset: 18
+            column: 12
+            offset: 11
           end:
             line: 1
-            column: 24
-            offset: 23
+            column: 19
+            offset: 18
         children: []
       - type: "text"
         value: " "
@@ -4577,13 +4577,13 @@ children:
             value: "  x\\n\\n\\n  y\\n"
             position:
               start:
-                line: 4
+                line: 3
                 column: 1
-                offset: 24
+                offset: 8
               end:
-                line: 8
+                line: 9
                 column: 1
-                offset: 34
+                offset: 46
 `;
 
 exports[`org/parser list long drawer in list 1`] = `
@@ -5490,8 +5490,8 @@ children:
           position:
             start:
               line: 2
-              column: 9
-              offset: 19
+              column: 1
+              offset: 11
             end:
               line: 2
               column: 25
@@ -5589,8 +5589,8 @@ children:
           position:
             start:
               line: 2
-              column: 20
-              offset: 30
+              column: 1
+              offset: 11
             end:
               line: 2
               column: 36
@@ -5644,8 +5644,8 @@ children:
           position:
             start:
               line: 2
-              column: 43
-              offset: 53
+              column: 31
+              offset: 41
             end:
               line: 2
               column: 59
@@ -5664,8 +5664,8 @@ children:
           position:
             start:
               line: 2
-              column: 70
-              offset: 80
+              column: 59
+              offset: 69
             end:
               line: 2
               column: 86
@@ -5684,8 +5684,8 @@ children:
           position:
             start:
               line: 2
-              column: 9
-              offset: 19
+              column: 1
+              offset: 11
             end:
               line: 2
               column: 31
@@ -5739,8 +5739,8 @@ children:
           position:
             start:
               line: 2
-              column: 9
-              offset: 19
+              column: 1
+              offset: 11
             end:
               line: 2
               column: 25
@@ -5810,8 +5810,8 @@ children:
           position:
             start:
               line: 2
-              column: 9
-              offset: 19
+              column: 1
+              offset: 11
             end:
               line: 2
               column: 25

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -274,10 +274,13 @@ children:
     value: "hello\\n"
     position:
       start:
-        line: 3
-        column: 14
-        offset: 35
-      end: {}
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 7
+        offset: 6
 `;
 
 exports[`org/parser blocks escaper in src block 1`] = `
@@ -792,8 +795,8 @@ children:
         offset: 0
       end:
         line: 1
-        column: 63
-        offset: 62
+        column: 54
+        offset: 53
 `;
 
 exports[`org/parser comments does not eat keyword 1`] = `
@@ -806,12 +809,12 @@ children:
     position:
       start:
         line: 1
-        column: 3
-        offset: 2
+        column: 1
+        offset: 0
       end:
-        line: 1
-        column: 18
-        offset: 17
+        line: 2
+        column: 1
+        offset: 18
   - type: "keyword"
     affiliated: {}
     key: "TITLE"
@@ -837,8 +840,8 @@ children:
     position:
       start:
         line: 1
-        column: 2
-        offset: 1
+        column: 1
+        offset: 0
       end:
         line: 1
         column: 2
@@ -855,12 +858,12 @@ children:
     position:
       start:
         line: 1
-        column: 3
-        offset: 2
+        column: 1
+        offset: 0
       end:
         line: 4
-        column: 1
-        offset: 32
+        column: 29
+        offset: 60
 `;
 
 exports[`org/parser comments no comments in list 1`] = `
@@ -904,8 +907,8 @@ children:
             position:
               start:
                 line: 3
-                column: 5
-                offset: 23
+                column: 1
+                offset: 19
               end:
                 line: 3
                 column: 12
@@ -922,8 +925,8 @@ children:
     position:
       start:
         line: 1
-        column: 3
-        offset: 2
+        column: 1
+        offset: 0
       end:
         line: 1
         column: 18
@@ -1452,8 +1455,8 @@ children:
             offset: 1
           end:
             line: 1
-            column: 7
-            offset: 6
+            column: 6
+            offset: 5
       - type: "text"
         value: ")"
         position:

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -11,6 +11,15 @@ children:
         - ""
         - "A"
     value: "Hello, world!"
+    position:
+      start:
+        line: 3
+        column: 1
+        offset: 15
+      end:
+        line: 3
+        column: 16
+        offset: 30
 `;
 
 exports[`org/parser affiliated keyword keyword renaming 1`] = `
@@ -22,6 +31,15 @@ children:
     affiliated:
       NAME: "hi"
     value: ""
+    position:
+      start:
+        line: 3
+        column: 1
+        offset: 26
+      end:
+        line: 3
+        column: 1
+        offset: 26
 `;
 
 exports[`org/parser affiliated keyword multiple keywords 1`] = `
@@ -35,11 +53,29 @@ children:
       CAPTION:
         - - type: "text"
             value: "hi\\n"
+            position:
+              start:
+                line: 2
+                column: 12
+                offset: 24
+              end:
+                line: 3
+                column: 1
+                offset: 27
     contentsBegin: 27
     contentsEnd: 36
     children:
       - type: "text"
         value: "paragraph"
+        position:
+          start:
+            line: 3
+            column: 1
+            offset: 27
+          end:
+            line: 3
+            column: 10
+            offset: 36
 `;
 
 exports[`org/parser affiliated keyword multiple same keywords 1`] = `
@@ -53,13 +89,40 @@ children:
       CAPTION:
         - - type: "text"
             value: "caption1\\n"
+            position:
+              start:
+                line: 4
+                column: 12
+                offset: 40
+              end:
+                line: 5
+                column: 1
+                offset: 49
         - - type: "text"
             value: "caption2\\n"
+            position:
+              start:
+                line: 5
+                column: 12
+                offset: 60
+              end:
+                line: 6
+                column: 1
+                offset: 69
     contentsBegin: 69
     contentsEnd: 78
     children:
       - type: "text"
         value: "paragraph"
+        position:
+          start:
+            line: 6
+            column: 1
+            offset: 69
+          end:
+            line: 6
+            column: 10
+            offset: 78
 `;
 
 exports[`org/parser affiliated keyword name 1`] = `
@@ -72,6 +135,15 @@ children:
       NAME: "source"
     language: "org"
     value: "some paragraph\\n"
+    position:
+      start:
+        line: 3
+        column: 1
+        offset: 31
+      end:
+        line: 4
+        column: 1
+        offset: 46
 `;
 
 exports[`org/parser affiliated keyword parsed keywords 1`] = `
@@ -84,17 +156,44 @@ children:
       CAPTION:
         - - type: "text"
             value: "hello "
+            position:
+              start:
+                line: 1
+                column: 12
+                offset: 11
+              end:
+                line: 1
+                column: 18
+                offset: 17
           - type: "bold"
             contentsBegin: 18
             contentsEnd: 23
             children:
               - type: "text"
                 value: "world"
+                position:
+                  start:
+                    line: 1
+                    column: 19
+                    offset: 18
+                  end:
+                    line: 1
+                    column: 24
+                    offset: 23
     contentsBegin: 25
     contentsEnd: 34
     children:
       - type: "text"
         value: "paragraph"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 25
+          end:
+            line: 2
+            column: 10
+            offset: 34
 `;
 
 exports[`org/parser blocks #+ escaper in src block 1`] = `
@@ -106,6 +205,15 @@ children:
     affiliated: {}
     language: "org"
     value: "#+ escaped\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 16
+      end:
+        line: 3
+        column: 1
+        offset: 28
 `;
 
 exports[`org/parser blocks center block 1`] = `
@@ -125,6 +233,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 15
+              end:
+                line: 3
+                column: 1
+                offset: 21
 `;
 
 exports[`org/parser blocks comma escaper in src block 1`] = `
@@ -136,6 +253,15 @@ children:
     affiliated: {}
     language: "org"
     value: ",,* two commas escaped\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 16
+      end:
+        line: 3
+        column: 1
+        offset: 40
 `;
 
 exports[`org/parser blocks comment block 1`] = `
@@ -146,6 +272,12 @@ children:
   - type: "comment-block"
     affiliated: {}
     value: "hello\\n"
+    position:
+      start:
+        line: 3
+        column: 14
+        offset: 35
+      end: {}
 `;
 
 exports[`org/parser blocks escaper in src block 1`] = `
@@ -157,6 +289,15 @@ children:
     affiliated: {}
     language: "c"
     value: "*a = 0;\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 14
+      end:
+        line: 3
+        column: 1
+        offset: 23
 `;
 
 exports[`org/parser blocks example block 1`] = `
@@ -167,6 +308,15 @@ children:
   - type: "example-block"
     affiliated: {}
     value: "hi\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 16
+      end:
+        line: 3
+        column: 1
+        offset: 19
 `;
 
 exports[`org/parser blocks export block 1`] = `
@@ -178,6 +328,15 @@ children:
     affiliated: {}
     backend: null
     value: "hi\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 15
+      end:
+        line: 3
+        column: 1
+        offset: 18
 `;
 
 exports[`org/parser blocks export block with backend 1`] = `
@@ -189,6 +348,15 @@ children:
     affiliated: {}
     backend: "html"
     value: "hi\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 20
+      end:
+        line: 3
+        column: 1
+        offset: 23
 `;
 
 exports[`org/parser blocks fake block 1`] = `
@@ -203,6 +371,15 @@ children:
     children:
       - type: "text"
         value: "#+nonblock\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 11
   - type: "special-block"
     affiliated: {}
     blockType: "block"
@@ -216,6 +393,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 25
+              end:
+                line: 4
+                column: 1
+                offset: 31
 `;
 
 exports[`org/parser blocks fake block 2 1`] = `
@@ -230,20 +416,56 @@ children:
     children:
       - type: "text"
         value: "#+ begin"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 9
+            offset: 8
       - type: "subscript"
         contentsBegin: 9
         contentsEnd: 12
         children:
           - type: "text"
             value: "src"
+            position:
+              start:
+                line: 1
+                column: 10
+                offset: 9
+              end:
+                line: 1
+                column: 13
+                offset: 12
       - type: "text"
         value: "\\nnot a block\\n#+end"
+        position:
+          start:
+            line: 1
+            column: 13
+            offset: 12
+          end:
+            line: 3
+            column: 6
+            offset: 30
       - type: "subscript"
         contentsBegin: 31
         contentsEnd: 34
         children:
           - type: "text"
             value: "src"
+            position:
+              start:
+                line: 3
+                column: 7
+                offset: 31
+              end:
+                line: 3
+                column: 10
+                offset: 34
 `;
 
 exports[`org/parser blocks fake escaper 1`] = `
@@ -255,6 +477,15 @@ children:
     affiliated: {}
     language: "org"
     value: ",# nont escaped\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 16
+      end:
+        line: 3
+        column: 1
+        offset: 32
 `;
 
 exports[`org/parser blocks headline escaper in src block 1`] = `
@@ -266,6 +497,15 @@ children:
     affiliated: {}
     language: "org"
     value: "* not a headline;\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 16
+      end:
+        line: 3
+        column: 1
+        offset: 35
 `;
 
 exports[`org/parser blocks incomplete block after paragraph 1`] = `
@@ -280,14 +520,41 @@ children:
     children:
       - type: "text"
         value: "hello\\n#+begin"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 8
+            offset: 13
       - type: "subscript"
         contentsBegin: 14
         contentsEnd: 17
         children:
           - type: "text"
             value: "src"
+            position:
+              start:
+                line: 2
+                column: 9
+                offset: 14
+              end:
+                line: 2
+                column: 12
+                offset: 17
       - type: "text"
         value: "\\nnot a code"
+        position:
+          start:
+            line: 2
+            column: 12
+            offset: 17
+          end:
+            line: 3
+            column: 11
+            offset: 28
 `;
 
 exports[`org/parser blocks quote block 1`] = `
@@ -307,6 +574,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 14
+              end:
+                line: 3
+                column: 1
+                offset: 20
 `;
 
 exports[`org/parser blocks special block 1`] = `
@@ -327,6 +603,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 13
+              end:
+                line: 3
+                column: 1
+                offset: 19
 `;
 
 exports[`org/parser blocks src block 1`] = `
@@ -337,6 +622,15 @@ children:
   - type: "src-block"
     affiliated: {}
     value: "hello\\n"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 12
+      end:
+        line: 3
+        column: 1
+        offset: 18
 `;
 
 exports[`org/parser blocks src in list 1`] = `
@@ -366,9 +660,27 @@ children:
             children:
               - type: "text"
                 value: "example:\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 12
           - type: "src-block"
             affiliated: {}
             value: "  blah\\n"
+            position:
+              start:
+                line: 4
+                column: 1
+                offset: 26
+              end:
+                line: 5
+                column: 1
+                offset: 33
 `;
 
 exports[`org/parser blocks verse block 1`] = `
@@ -390,6 +702,15 @@ children:
 
 
           \\    ---AlexSchroeder\\n"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 14
+          end:
+            line: 7
+            column: 1
+            offset: 110
 `;
 
 exports[`org/parser clock clock in progress 1`] = `
@@ -409,8 +730,26 @@ children:
         hour: 14
         minute: 36
       end: null
+      position:
+        start:
+          line: 1
+          column: 8
+          offset: 7
+        end:
+          line: 1
+          column: 30
+          offset: 29
     duration: null
     status: "running"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 30
+        offset: 29
 `;
 
 exports[`org/parser clock finished clock 1`] = `
@@ -435,8 +774,26 @@ children:
         day: 22
         hour: 11
         minute: 10
+      position:
+        start:
+          line: 1
+          column: 8
+          offset: 7
+        end:
+          line: 1
+          column: 54
+          offset: 53
     duration: "2:03"
     status: "closed"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 63
+        offset: 62
 `;
 
 exports[`org/parser comments does not eat keyword 1`] = `
@@ -446,10 +803,28 @@ contentsEnd: 32
 children:
   - type: "comment"
     value: "this is comment"
+    position:
+      start:
+        line: 1
+        column: 3
+        offset: 2
+      end:
+        line: 1
+        column: 18
+        offset: 17
   - type: "keyword"
     affiliated: {}
     key: "TITLE"
     value: "hello"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 18
+      end:
+        line: 2
+        column: 15
+        offset: 32
 `;
 
 exports[`org/parser comments empty comment 1`] = `
@@ -459,6 +834,15 @@ contentsEnd: 1
 children:
   - type: "comment"
     value: ""
+    position:
+      start:
+        line: 1
+        column: 2
+        offset: 1
+      end:
+        line: 1
+        column: 2
+        offset: 1
 `;
 
 exports[`org/parser comments multi-line comment 1`] = `
@@ -468,6 +852,15 @@ contentsEnd: 60
 children:
   - type: "comment"
     value: "first line\\nsecond\\nthird\\nfourth"
+    position:
+      start:
+        line: 1
+        column: 3
+        offset: 2
+      end:
+        line: 4
+        column: 1
+        offset: 32
 `;
 
 exports[`org/parser comments no comments in list 1`] = `
@@ -497,8 +890,26 @@ children:
             children:
               - type: "text"
                 value: "# not a comment\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 19
           - type: "comment"
             value: "comment"
+            position:
+              start:
+                line: 3
+                column: 5
+                offset: 23
+              end:
+                line: 3
+                column: 12
+                offset: 30
 `;
 
 exports[`org/parser comments single-line comment 1`] = `
@@ -508,6 +919,15 @@ contentsEnd: 17
 children:
   - type: "comment"
     value: "this is comment"
+    position:
+      start:
+        line: 1
+        column: 3
+        offset: 2
+      end:
+        line: 1
+        column: 18
+        offset: 17
 `;
 
 exports[`org/parser complete drawer after paragraph 1`] = `
@@ -522,6 +942,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 1
+          end:
+            line: 3
+            column: 1
+            offset: 7
   - type: "drawer"
     affiliated: {}
     name: "DRAWER"
@@ -535,6 +964,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 4
+                column: 1
+                offset: 16
+              end:
+                line: 5
+                column: 1
+                offset: 22
 `;
 
 exports[`org/parser complete lowercase drawer after paragraph 1`] = `
@@ -549,6 +987,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 1
+          end:
+            line: 3
+            column: 1
+            offset: 7
   - type: "drawer"
     affiliated: {}
     name: "drawer"
@@ -562,6 +1009,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 4
+                column: 1
+                offset: 16
+              end:
+                line: 5
+                column: 1
+                offset: 22
 `;
 
 exports[`org/parser custom drawer 1`] = `
@@ -582,12 +1038,30 @@ children:
         children:
           - type: "text"
             value: "hello "
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 11
+              end:
+                line: 2
+                column: 7
+                offset: 17
           - type: "italic"
             contentsBegin: 18
             contentsEnd: 23
             children:
               - type: "text"
                 value: "there"
+                position:
+                  start:
+                    line: 2
+                    column: 8
+                    offset: 18
+                  end:
+                    line: 2
+                    column: 13
+                    offset: 23
 `;
 
 exports[`org/parser diary sexp 1`] = `
@@ -598,6 +1072,15 @@ children:
   - type: "diary-sexp"
     affiliated: {}
     value: "%%(diary-anniversary 10 31 1948) Arthur's birthday (%d years old)"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 66
+        offset: 65
 `;
 
 exports[`org/parser diary sexp with newline following 1`] = `
@@ -608,6 +1091,15 @@ children:
   - type: "diary-sexp"
     affiliated: {}
     value: "%%(diary-anniversaries)"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 24
+        offset: 23
 `;
 
 exports[`org/parser dual keyword inside paragraph 1`] = `
@@ -622,6 +1114,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n#+RESULTS[hi]: hello\\nthere\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 1
+            offset: 33
 `;
 
 exports[`org/parser emphasis marks C++ accidental strike-through 1`] = `
@@ -636,6 +1137,15 @@ children:
     children:
       - type: "text"
         value: "C++ blah C++"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser emphasis marks bold 1`] = `
@@ -654,6 +1164,15 @@ children:
         children:
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 1
+                column: 2
+                offset: 1
+              end:
+                line: 1
+                column: 7
+                offset: 6
 `;
 
 exports[`org/parser emphasis marks emphasis 1`] = `
@@ -672,32 +1191,104 @@ children:
         children:
           - type: "text"
             value: "Consider"
+            position:
+              start:
+                line: 1
+                column: 2
+                offset: 1
+              end:
+                line: 1
+                column: 10
+                offset: 9
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 11
+            offset: 10
+          end:
+            line: 1
+            column: 12
+            offset: 11
       - type: "code"
         value: "t*h*e"
+        position:
+          start:
+            line: 1
+            column: 19
+            offset: 18
+          end:
+            line: 1
+            column: 24
+            offset: 23
         children: []
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 19
+            offset: 18
+          end:
+            line: 1
+            column: 20
+            offset: 19
       - type: "bold"
         contentsBegin: 20
         contentsEnd: 29
         children:
           - type: "text"
             value: "following"
+            position:
+              start:
+                line: 1
+                column: 21
+                offset: 20
+              end:
+                line: 1
+                column: 30
+                offset: 29
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 31
+            offset: 30
+          end:
+            line: 1
+            column: 32
+            offset: 31
       - type: "verbatim"
         value: "example"
         children: []
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 41
+            offset: 40
+          end:
+            line: 1
+            column: 42
+            offset: 41
       - type: "strike-through"
         contentsBegin: 42
         contentsEnd: 48
         children:
           - type: "text"
             value: "strike"
+            position:
+              start:
+                line: 1
+                column: 43
+                offset: 42
+              end:
+                line: 1
+                column: 49
+                offset: 48
 `;
 
 exports[`org/parser emphasis marks emphasis boundaries 1`] = `
@@ -712,14 +1303,41 @@ children:
     children:
       - type: "text"
         value: "a/a/ b*b* c~c~ d=d= e+e+ f"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 27
+            offset: 26
       - type: "subscript"
         contentsBegin: 27
         contentsEnd: 28
         children:
           - type: "text"
             value: "f"
+            position:
+              start:
+                line: 1
+                column: 28
+                offset: 27
+              end:
+                line: 1
+                column: 29
+                offset: 28
       - type: "text"
         value: "_"
+        position:
+          start:
+            line: 1
+            column: 29
+            offset: 28
+          end:
+            line: 1
+            column: 30
+            offset: 29
 `;
 
 exports[`org/parser emphasis marks hanging / 1`] = `
@@ -749,6 +1367,15 @@ children:
             children:
               - type: "text"
                 value: "hello/other"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 1
+                    column: 14
+                    offset: 13
 `;
 
 exports[`org/parser empty document 1`] = `
@@ -777,6 +1404,15 @@ children:
         ascii: "A"
         latin1: "À"
         utf8: "À"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 8
+            offset: 7
 `;
 
 exports[`org/parser entity in parentheses 1`] = `
@@ -791,6 +1427,15 @@ children:
     children:
       - type: "text"
         value: "("
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "entity"
         useBrackets: false
         name: "leq"
@@ -800,8 +1445,26 @@ children:
         ascii: "<="
         latin1: "<="
         utf8: "≤"
+        position:
+          start:
+            line: 1
+            column: 2
+            offset: 1
+          end:
+            line: 1
+            column: 7
+            offset: 6
       - type: "text"
         value: ")"
+        position:
+          start:
+            line: 1
+            column: 6
+            offset: 5
+          end:
+            line: 1
+            column: 7
+            offset: 6
 `;
 
 exports[`org/parser fake keyword 1`] = `
@@ -816,6 +1479,15 @@ children:
     children:
       - type: "text"
         value: "#+ title: hi"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser fake multiline fragment 1`] = `
@@ -830,6 +1502,15 @@ children:
     children:
       - type: "text"
         value: "hello $2\\n2\\n2\\n2 world"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 8
+            offset: 20
 `;
 
 exports[`org/parser file property drawer 1`] = `
@@ -844,6 +1525,15 @@ children:
       - type: "node-property"
         key: "ID"
         value: "01c7615e-d792-4d06-995b-19a2c046c055"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 13
+          end:
+            line: 3
+            column: 1
+            offset: 61
 `;
 
 exports[`org/parser fixed-width empty fixed-width 1`] = `
@@ -854,6 +1544,15 @@ children:
   - type: "fixed-width"
     affiliated: {}
     value: ""
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 2
+        offset: 1
 `;
 
 exports[`org/parser fixed-width multi-line fixed-width 1`] = `
@@ -864,6 +1563,15 @@ children:
   - type: "fixed-width"
     affiliated: {}
     value: "hello\\n  world"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 2
+        column: 10
+        offset: 17
 `;
 
 exports[`org/parser fixed-width single-line fixed-width 1`] = `
@@ -874,6 +1582,15 @@ children:
   - type: "fixed-width"
     affiliated: {}
     value: "hello"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 8
+        offset: 7
 `;
 
 exports[`org/parser footnote definition footnote definition splits paragraph 1`] = `
@@ -888,6 +1605,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
   - type: "footnote-definition"
     affiliated: {}
     label: "1"
@@ -901,6 +1627,15 @@ children:
         children:
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 2
+                column: 8
+                offset: 13
+              end:
+                line: 2
+                column: 13
+                offset: 18
 `;
 
 exports[`org/parser footnote definition footnote definition with : following 1`] = `
@@ -921,6 +1656,15 @@ children:
         children:
           - type: "text"
             value: ": footnote"
+            position:
+              start:
+                line: 1
+                column: 7
+                offset: 6
+              end:
+                line: 1
+                column: 17
+                offset: 16
 `;
 
 exports[`org/parser footnote definition paragraph split 1`] = `
@@ -941,6 +1685,15 @@ children:
         children:
           - type: "text"
             value: "hello\\n"
+            position:
+              start:
+                line: 2
+                column: 12
+                offset: 12
+              end:
+                line: 3
+                column: 1
+                offset: 18
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 20
@@ -948,6 +1701,15 @@ children:
     children:
       - type: "text"
         value: "next paragraph"
+        position:
+          start:
+            line: 5
+            column: 1
+            offset: 20
+          end:
+            line: 5
+            column: 15
+            offset: 34
 `;
 
 exports[`org/parser footnote definition sequential 1`] = `
@@ -968,6 +1730,15 @@ children:
         children:
           - type: "text"
             value: "footnote1\\n"
+            position:
+              start:
+                line: 2
+                column: 12
+                offset: 12
+              end:
+                line: 3
+                column: 1
+                offset: 22
   - type: "footnote-definition"
     affiliated: {}
     label: "2"
@@ -981,6 +1752,15 @@ children:
         children:
           - type: "text"
             value: "footnote2\\n"
+            position:
+              start:
+                line: 3
+                column: 8
+                offset: 29
+              end:
+                line: 4
+                column: 1
+                offset: 39
 `;
 
 exports[`org/parser footnote definition sequential with affiliated keywords 1`] = `
@@ -1002,6 +1782,15 @@ children:
         children:
           - type: "text"
             value: "footnote1\\n"
+            position:
+              start:
+                line: 3
+                column: 12
+                offset: 23
+              end:
+                line: 4
+                column: 1
+                offset: 33
   - type: "footnote-definition"
     affiliated:
       NAME: "f2"
@@ -1016,6 +1805,15 @@ children:
         children:
           - type: "text"
             value: "footnote2\\n"
+            position:
+              start:
+                line: 5
+                column: 8
+                offset: 51
+              end:
+                line: 6
+                column: 1
+                offset: 61
 `;
 
 exports[`org/parser footnote definition simple 1`] = `
@@ -1036,6 +1834,15 @@ children:
         children:
           - type: "text"
             value: "this is footnote definition\\n"
+            position:
+              start:
+                line: 2
+                column: 12
+                offset: 12
+              end:
+                line: 3
+                column: 1
+                offset: 40
 `;
 
 exports[`org/parser footnote definition starting on next line 1`] = `
@@ -1056,6 +1863,15 @@ children:
         children:
           - type: "text"
             value: "footnote\\n"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 12
+              end:
+                line: 4
+                column: 1
+                offset: 21
 `;
 
 exports[`org/parser footnote-reference inline reference 1`] = `
@@ -1070,6 +1886,15 @@ children:
     children:
       - type: "text"
         value: "hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 6
+            offset: 5
       - type: "footnote-reference"
         label: null
         footnoteType: "inline"
@@ -1078,14 +1903,41 @@ children:
         children:
           - type: "text"
             value: " this is inline "
+            position:
+              start:
+                line: 1
+                column: 11
+                offset: 10
+              end:
+                line: 1
+                column: 27
+                offset: 26
           - type: "italic"
             contentsBegin: 27
             contentsEnd: 35
             children:
               - type: "text"
                 value: "footnote"
+                position:
+                  start:
+                    line: 1
+                    column: 28
+                    offset: 27
+                  end:
+                    line: 1
+                    column: 36
+                    offset: 35
           - type: "text"
             value: " definition"
+            position:
+              start:
+                line: 1
+                column: 37
+                offset: 36
+              end:
+                line: 1
+                column: 48
+                offset: 47
 `;
 
 exports[`org/parser footnote-reference named inline reference 1`] = `
@@ -1100,6 +1952,15 @@ children:
     children:
       - type: "text"
         value: "hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 6
+            offset: 5
       - type: "footnote-reference"
         label: "name"
         footnoteType: "inline"
@@ -1108,14 +1969,41 @@ children:
         children:
           - type: "text"
             value: " this is inline "
+            position:
+              start:
+                line: 1
+                column: 15
+                offset: 14
+              end:
+                line: 1
+                column: 31
+                offset: 30
           - type: "italic"
             contentsBegin: 31
             contentsEnd: 39
             children:
               - type: "text"
                 value: "footnote"
+                position:
+                  start:
+                    line: 1
+                    column: 32
+                    offset: 31
+                  end:
+                    line: 1
+                    column: 40
+                    offset: 39
           - type: "text"
             value: " definition"
+            position:
+              start:
+                line: 1
+                column: 41
+                offset: 40
+              end:
+                line: 1
+                column: 52
+                offset: 51
 `;
 
 exports[`org/parser footnote-reference standard reference 1`] = `
@@ -1130,6 +2018,15 @@ children:
     children:
       - type: "text"
         value: "hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 6
+            offset: 5
       - type: "footnote-reference"
         label: "1"
         footnoteType: "standard"
@@ -1157,6 +2054,15 @@ children:
         children:
           - type: "text"
             value: "Headline 1"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 13
+                offset: 12
   - type: "section"
     contentsBegin: 14
     contentsEnd: 31
@@ -1173,6 +2079,15 @@ children:
         children:
           - type: "text"
             value: "Headline 2"
+            position:
+              start:
+                line: 3
+                column: 8
+                offset: 21
+              end:
+                line: 3
+                column: 18
+                offset: 31
 `;
 
 exports[`org/parser headline complex headline + newline 1`] = `
@@ -1198,14 +2113,41 @@ children:
         children:
           - type: "text"
             value: "headline "
+            position:
+              start:
+                line: 1
+                column: 21
+                offset: 20
+              end:
+                line: 1
+                column: 30
+                offset: 29
           - type: "italic"
             contentsBegin: 30
             contentsEnd: 36
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 31
+                    offset: 30
+                  end:
+                    line: 1
+                    column: 37
+                    offset: 36
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 38
+                offset: 37
+              end:
+                line: 1
+                column: 44
+                offset: 43
 `;
 
 exports[`org/parser headline complex headline 1`] = `
@@ -1231,14 +2173,41 @@ children:
         children:
           - type: "text"
             value: "headline "
+            position:
+              start:
+                line: 1
+                column: 21
+                offset: 20
+              end:
+                line: 1
+                column: 30
+                offset: 29
           - type: "italic"
             contentsBegin: 30
             contentsEnd: 36
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 31
+                    offset: 30
+                  end:
+                    line: 1
+                    column: 37
+                    offset: 36
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 38
+                offset: 37
+              end:
+                line: 1
+                column: 44
+                offset: 43
 `;
 
 exports[`org/parser headline custom todo keywords 1`] = `
@@ -1262,6 +2231,15 @@ children:
         children:
           - type: "text"
             value: "my custom todo keyword"
+            position:
+              start:
+                line: 1
+                column: 8
+                offset: 7
+              end:
+                line: 1
+                column: 30
+                offset: 29
 `;
 
 exports[`org/parser headline multiple headlines 1`] = `
@@ -1285,6 +2263,15 @@ children:
         children:
           - type: "text"
             value: "Hello"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 8
+                offset: 7
   - type: "section"
     contentsBegin: 8
     contentsEnd: 16
@@ -1301,6 +2288,15 @@ children:
         children:
           - type: "text"
             value: "World"
+            position:
+              start:
+                line: 2
+                column: 3
+                offset: 10
+              end:
+                line: 2
+                column: 8
+                offset: 15
   - type: "section"
     contentsBegin: 16
     contentsEnd: 22
@@ -1317,6 +2313,15 @@ children:
         children:
           - type: "text"
             value: "blah"
+            position:
+              start:
+                line: 3
+                column: 3
+                offset: 18
+              end:
+                line: 3
+                column: 7
+                offset: 22
 `;
 
 exports[`org/parser headline nested headlines 1`] = `
@@ -1340,6 +2345,15 @@ children:
         children:
           - type: "text"
             value: "hi"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 5
+                offset: 4
       - type: "section"
         contentsBegin: 5
         contentsEnd: 22
@@ -1356,6 +2370,15 @@ children:
             children:
               - type: "text"
                 value: "there"
+                position:
+                  start:
+                    line: 2
+                    column: 4
+                    offset: 8
+                  end:
+                    line: 2
+                    column: 9
+                    offset: 13
           - type: "section"
             contentsBegin: 14
             contentsEnd: 22
@@ -1372,6 +2395,15 @@ children:
                 children:
                   - type: "text"
                     value: "how"
+                    position:
+                      start:
+                        line: 3
+                        column: 5
+                        offset: 18
+                      end:
+                        line: 3
+                        column: 8
+                        offset: 21
   - type: "section"
     contentsBegin: 22
     contentsEnd: 36
@@ -1388,6 +2420,15 @@ children:
         children:
           - type: "text"
             value: "are"
+            position:
+              start:
+                line: 4
+                column: 3
+                offset: 24
+              end:
+                line: 4
+                column: 6
+                offset: 27
       - type: "section"
         contentsBegin: 28
         contentsEnd: 36
@@ -1404,6 +2445,15 @@ children:
             children:
               - type: "text"
                 value: "you"
+                position:
+                  start:
+                    line: 5
+                    column: 5
+                    offset: 32
+                  end:
+                    line: 5
+                    column: 8
+                    offset: 35
 `;
 
 exports[`org/parser headline single headline 1`] = `
@@ -1427,6 +2477,15 @@ children:
         children:
           - type: "text"
             value: "Hello"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 8
+                offset: 7
 `;
 
 exports[`org/parser headline statistics-cookie complex headline with defined fraction statistics-cookie 1`] = `
@@ -1457,14 +2516,41 @@ children:
             postBlank: 1
           - type: "text"
             value: "COMMENT headline "
+            position:
+              start:
+                line: 1
+                column: 19
+                offset: 18
+              end:
+                line: 1
+                column: 36
+                offset: 35
           - type: "italic"
             contentsBegin: 36
             contentsEnd: 42
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 37
+                    offset: 36
+                  end:
+                    line: 1
+                    column: 43
+                    offset: 42
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 44
+                offset: 43
+              end:
+                line: 1
+                column: 50
+                offset: 49
 `;
 
 exports[`org/parser headline statistics-cookie complex headline with defined fraction statistics-cookie 2`] = `
@@ -1488,14 +2574,41 @@ children:
         children:
           - type: "text"
             value: "headline "
+            position:
+              start:
+                line: 1
+                column: 21
+                offset: 20
+              end:
+                line: 1
+                column: 30
+                offset: 29
           - type: "italic"
             contentsBegin: 30
             contentsEnd: 36
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 31
+                    offset: 30
+                  end:
+                    line: 1
+                    column: 37
+                    offset: 36
           - type: "text"
             value: " title :some:tags: "
+            position:
+              start:
+                line: 1
+                column: 38
+                offset: 37
+              end:
+                line: 1
+                column: 57
+                offset: 56
           - type: "statistics-cookie"
             begin: 56
             end: 61
@@ -1531,14 +2644,41 @@ children:
             postBlank: 1
           - type: "text"
             value: "COMMENT headline "
+            position:
+              start:
+                line: 1
+                column: 19
+                offset: 18
+              end:
+                line: 1
+                column: 36
+                offset: 35
           - type: "italic"
             contentsBegin: 36
             contentsEnd: 42
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 37
+                    offset: 36
+                  end:
+                    line: 1
+                    column: 43
+                    offset: 42
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 44
+                offset: 43
+              end:
+                line: 1
+                column: 50
+                offset: 49
 `;
 
 exports[`org/parser headline statistics-cookie complex headline with empty fraction statistics-cookie 1`] = `
@@ -1569,14 +2709,41 @@ children:
             postBlank: 1
           - type: "text"
             value: "COMMENT headline "
+            position:
+              start:
+                line: 1
+                column: 17
+                offset: 16
+              end:
+                line: 1
+                column: 34
+                offset: 33
           - type: "italic"
             contentsBegin: 34
             contentsEnd: 40
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 35
+                    offset: 34
+                  end:
+                    line: 1
+                    column: 41
+                    offset: 40
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 42
+                offset: 41
+              end:
+                line: 1
+                column: 48
+                offset: 47
 `;
 
 exports[`org/parser headline statistics-cookie complex headline with empty percentage statistics-cookie 1`] = `
@@ -1607,14 +2774,41 @@ children:
             postBlank: 1
           - type: "text"
             value: "COMMENT headline "
+            position:
+              start:
+                line: 1
+                column: 17
+                offset: 16
+              end:
+                line: 1
+                column: 34
+                offset: 33
           - type: "italic"
             contentsBegin: 34
             contentsEnd: 40
             children:
               - type: "text"
                 value: "italic"
+                position:
+                  start:
+                    line: 1
+                    column: 35
+                    offset: 34
+                  end:
+                    line: 1
+                    column: 41
+                    offset: 40
           - type: "text"
             value: " title"
+            position:
+              start:
+                line: 1
+                column: 42
+                offset: 41
+              end:
+                line: 1
+                column: 48
+                offset: 47
 `;
 
 exports[`org/parser headline statistics-cookie headline starting with fraction statistics-cookie 1`] = `
@@ -1643,6 +2837,15 @@ children:
             postBlank: 1
           - type: "text"
             value: "Something"
+            position:
+              start:
+                line: 1
+                column: 11
+                offset: 10
+              end:
+                line: 1
+                column: 20
+                offset: 19
 `;
 
 exports[`org/parser headline statistics-cookie statistics cookie with long trailing space 1`] = `
@@ -1671,6 +2874,15 @@ children:
             postBlank: 4
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 1
+                column: 10
+                offset: 9
+              end:
+                line: 1
+                column: 15
+                offset: 14
 `;
 
 exports[`org/parser headline statistics-cookie statistics cookie without trailing space 1`] = `
@@ -1699,6 +2911,15 @@ children:
             postBlank: 0
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 1
+                column: 6
+                offset: 5
+              end:
+                line: 1
+                column: 11
+                offset: 10
 `;
 
 exports[`org/parser horizontal rule 1`] = `
@@ -1722,6 +2943,15 @@ children:
     children:
       - type: "text"
         value: "Hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
   - type: "horizontal-rule"
     affiliated: {}
   - type: "paragraph"
@@ -1731,6 +2961,15 @@ children:
     children:
       - type: "text"
         value: "World"
+        position:
+          start:
+            line: 5
+            column: 1
+            offset: 14
+          end:
+            line: 5
+            column: 6
+            offset: 19
 `;
 
 exports[`org/parser incomplete drawer 1`] = `
@@ -1745,6 +2984,15 @@ children:
     children:
       - type: "text"
         value: ":NONDRAWER:\\nI have no :END:"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 16
+            offset: 27
 `;
 
 exports[`org/parser incomplete drawer after paragraph 1`] = `
@@ -1759,6 +3007,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n:NONDRAWER:\\nhello"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 1
+          end:
+            line: 4
+            column: 6
+            offset: 24
 `;
 
 exports[`org/parser keyword 1`] = `
@@ -1770,6 +3027,15 @@ children:
     affiliated: {}
     key: "TITLE"
     value: "hi"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 12
+        offset: 11
 `;
 
 exports[`org/parser latex environment environment with star 1`] = `
@@ -1784,6 +3050,15 @@ children:
       blah
 
       \\\\end{equation*}"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 1
+      end:
+        line: 4
+        column: 16
+        offset: 39
 `;
 
 exports[`org/parser latex environment incomplete latex environment after paragraph (two lines) 1`] = `
@@ -1798,11 +3073,38 @@ children:
     children:
       - type: "text"
         value: "hello\\nthere\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 3
+            column: 1
+            offset: 12
       - type: "latex-fragment"
         value: "\\\\begin{hello}"
         contents: "\\\\begin{hello}"
+        position:
+          start:
+            line: 3
+            column: 1
+            offset: 12
+          end:
+            line: 3
+            column: 14
+            offset: 25
       - type: "text"
         value: "\\nI am incomplete"
+        position:
+          start:
+            line: 3
+            column: 14
+            offset: 25
+          end:
+            line: 4
+            column: 16
+            offset: 41
 `;
 
 exports[`org/parser latex environment incomplete latex environment after paragraph 1`] = `
@@ -1817,11 +3119,38 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
       - type: "latex-fragment"
         value: "\\\\begin{hello}"
         contents: "\\\\begin{hello}"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 6
+          end:
+            line: 2
+            column: 14
+            offset: 19
       - type: "text"
         value: "\\nI am incomplete"
+        position:
+          start:
+            line: 2
+            column: 14
+            offset: 19
+          end:
+            line: 3
+            column: 16
+            offset: 35
 `;
 
 exports[`org/parser latex environment latex environment after paragraph 1`] = `
@@ -1836,9 +3165,27 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
   - type: "latex-environment"
     affiliated: {}
     value: "\\\\begin{hello} there \\\\end{hello}"
+    position:
+      start:
+        line: 2
+        column: 1
+        offset: 6
+      end:
+        line: 2
+        column: 32
+        offset: 37
 `;
 
 exports[`org/parser latex environment multi-line 1`] = `
@@ -1853,6 +3200,15 @@ children:
       some text
 
       \\\\end{hello}"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 3
+        column: 12
+        offset: 35
 `;
 
 exports[`org/parser latex-fragment 1`] = `
@@ -1867,26 +3223,107 @@ children:
     children:
       - type: "text"
         value: "If "
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 4
+            offset: 3
       - type: "latex-fragment"
         value: "$a^2=b$"
         contents: "a^2=b"
+        position:
+          start:
+            line: 1
+            column: 4
+            offset: 3
+          end:
+            line: 1
+            column: 11
+            offset: 10
       - type: "text"
         value: " and "
+        position:
+          start:
+            line: 1
+            column: 11
+            offset: 10
+          end:
+            line: 1
+            column: 16
+            offset: 15
       - type: "latex-fragment"
         value: "\\\\( b=2 \\\\)"
         contents: " b=2 "
+        position:
+          start:
+            line: 1
+            column: 16
+            offset: 15
+          end:
+            line: 1
+            column: 25
+            offset: 24
       - type: "text"
         value: ", then the solution must be\\neither "
+        position:
+          start:
+            line: 1
+            column: 25
+            offset: 24
+          end:
+            line: 2
+            column: 8
+            offset: 59
       - type: "latex-fragment"
         value: "$$ a=+\\\\sqrt{2} $$"
         contents: " a=+\\\\sqrt{2} "
+        position:
+          start:
+            line: 2
+            column: 8
+            offset: 59
+          end:
+            line: 2
+            column: 25
+            offset: 76
       - type: "text"
         value: " or "
+        position:
+          start:
+            line: 2
+            column: 25
+            offset: 76
+          end:
+            line: 2
+            column: 29
+            offset: 80
       - type: "latex-fragment"
         value: "\\\\[ a=-\\\\sqrt{2} \\\\]"
         contents: " a=-\\\\sqrt{2} "
+        position:
+          start:
+            line: 2
+            column: 29
+            offset: 80
+          end:
+            line: 2
+            column: 46
+            offset: 97
       - type: "text"
         value: "."
+        position:
+          start:
+            line: 2
+            column: 46
+            offset: 97
+          end:
+            line: 2
+            column: 47
+            offset: 98
 `;
 
 exports[`org/parser links ./ as start of file link 1`] = `
@@ -2009,6 +3446,15 @@ children:
     children:
       - type: "text"
         value: "some text "
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 11
+            offset: 10
       - type: "link"
         format: "bracket"
         linkType: "fuzzy"
@@ -2019,6 +3465,15 @@ children:
         children:
           - type: "text"
             value: "text"
+            position:
+              start:
+                line: 1
+                column: 19
+                offset: 18
+              end:
+                line: 1
+                column: 23
+                offset: 22
 `;
 
 exports[`org/parser links link mixed with text 1`] = `
@@ -2033,6 +3488,15 @@ children:
     children:
       - type: "text"
         value: "hello "
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
       - type: "link"
         format: "plain"
         linkType: "http"
@@ -2041,6 +3505,15 @@ children:
         children: []
       - type: "text"
         value: " blah"
+        position:
+          start:
+            line: 1
+            column: 25
+            offset: 24
+          end:
+            line: 1
+            column: 30
+            offset: 29
 `;
 
 exports[`org/parser links link with no text 1`] = `
@@ -2081,6 +3554,15 @@ children:
         children:
           - type: "text"
             value: "line1\\nline2"
+            position:
+              start:
+                line: 1
+                column: 22
+                offset: 21
+              end:
+                line: 2
+                column: 6
+                offset: 32
 `;
 
 exports[`org/parser links plain link does not include trailing punctuation 1`] = `
@@ -2095,6 +3577,15 @@ children:
     children:
       - type: "text"
         value: "Example: "
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 10
+            offset: 9
       - type: "link"
         format: "plain"
         linkType: "http"
@@ -2103,6 +3594,15 @@ children:
         children: []
       - type: "text"
         value: "."
+        position:
+          start:
+            line: 1
+            column: 28
+            offset: 27
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser links regular link 1`] = `
@@ -2125,6 +3625,15 @@ children:
         children:
           - type: "text"
             value: "text"
+            position:
+              start:
+                line: 1
+                column: 9
+                offset: 8
+              end:
+                line: 1
+                column: 13
+                offset: 12
 `;
 
 exports[`org/parser links regular link with longer link slash 1`] = `
@@ -2147,6 +3656,15 @@ children:
         children:
           - type: "text"
             value: "text"
+            position:
+              start:
+                line: 1
+                column: 13
+                offset: 12
+              end:
+                line: 1
+                column: 17
+                offset: 16
 `;
 
 exports[`org/parser links two links in one line 1`] = `
@@ -2169,8 +3687,26 @@ children:
         children:
           - type: "text"
             value: "text1"
+            position:
+              start:
+                line: 1
+                column: 10
+                offset: 9
+              end:
+                line: 1
+                column: 15
+                offset: 14
       - type: "text"
         value: " "
+        position:
+          start:
+            line: 1
+            column: 17
+            offset: 16
+          end:
+            line: 1
+            column: 18
+            offset: 17
       - type: "link"
         format: "bracket"
         linkType: "fuzzy"
@@ -2181,6 +3717,15 @@ children:
         children:
           - type: "text"
             value: "text2"
+            position:
+              start:
+                line: 1
+                column: 27
+                offset: 26
+              end:
+                line: 1
+                column: 32
+                offset: 31
 `;
 
 exports[`org/parser list checkbox item [ ] 1`] = `
@@ -2210,6 +3755,15 @@ children:
             children:
               - type: "text"
                 value: "not done"
+                position:
+                  start:
+                    line: 1
+                    column: 7
+                    offset: 6
+                  end:
+                    line: 1
+                    column: 15
+                    offset: 14
 `;
 
 exports[`org/parser list checkbox item [-] 1`] = `
@@ -2239,6 +3793,15 @@ children:
             children:
               - type: "text"
                 value: "half-done"
+                position:
+                  start:
+                    line: 1
+                    column: 7
+                    offset: 6
+                  end:
+                    line: 1
+                    column: 16
+                    offset: 15
 `;
 
 exports[`org/parser list checkbox item [X] 1`] = `
@@ -2268,6 +3831,15 @@ children:
             children:
               - type: "text"
                 value: "done"
+                position:
+                  start:
+                    line: 1
+                    column: 7
+                    offset: 6
+                  end:
+                    line: 1
+                    column: 11
+                    offset: 10
 `;
 
 exports[`org/parser list checkbox item [x] 1`] = `
@@ -2297,6 +3869,15 @@ children:
             children:
               - type: "text"
                 value: "done"
+                position:
+                  start:
+                    line: 1
+                    column: 7
+                    offset: 6
+                  end:
+                    line: 1
+                    column: 11
+                    offset: 10
 `;
 
 exports[`org/parser list description list > skips trailing spaces after tag 1`] = `
@@ -2323,6 +3904,15 @@ children:
             children:
               - type: "text"
                 value: "term"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 1
+                    column: 7
+                    offset: 6
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 13
@@ -2330,6 +3920,15 @@ children:
             children:
               - type: "text"
                 value: "description"
+                position:
+                  start:
+                    line: 1
+                    column: 14
+                    offset: 13
+                  end:
+                    line: 1
+                    column: 25
+                    offset: 24
 `;
 
 exports[`org/parser list description list 1`] = `
@@ -2356,6 +3955,15 @@ children:
             children:
               - type: "text"
                 value: "term1"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 1
+                    column: 8
+                    offset: 7
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 11
@@ -2363,6 +3971,15 @@ children:
             children:
               - type: "text"
                 value: "description 1\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 12
+                    offset: 11
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 25
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2375,6 +3992,15 @@ children:
             children:
               - type: "text"
                 value: "term 2"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 27
+                  end:
+                    line: 2
+                    column: 9
+                    offset: 33
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 37
@@ -2382,6 +4008,15 @@ children:
             children:
               - type: "text"
                 value: "description 2"
+                position:
+                  start:
+                    line: 2
+                    column: 13
+                    offset: 37
+                  end:
+                    line: 2
+                    column: 26
+                    offset: 50
 `;
 
 exports[`org/parser list empty line between list items 1`] = `
@@ -2411,6 +4046,15 @@ children:
             children:
               - type: "text"
                 value: "item 1\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 9
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2426,6 +4070,15 @@ children:
             children:
               - type: "text"
                 value: "item 2"
+                position:
+                  start:
+                    line: 3
+                    column: 3
+                    offset: 12
+                  end:
+                    line: 3
+                    column: 9
+                    offset: 18
 `;
 
 exports[`org/parser list fake list numbers 1`] = `
@@ -2455,6 +4108,15 @@ children:
             children:
               - type: "text"
                 value: "1. blah"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 1
+                    column: 10
+                    offset: 9
 `;
 
 exports[`org/parser list formatting in description list tags 1`] = `
@@ -2489,6 +4151,15 @@ children:
                 children:
                   - type: "text"
                     value: "Example"
+                    position:
+                      start:
+                        line: 2
+                        column: 26
+                        offset: 26
+                      end:
+                        line: 2
+                        column: 33
+                        offset: 33
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 39
@@ -2496,6 +4167,15 @@ children:
             children:
               - type: "text"
                 value: "Hello there!\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 39
+                    offset: 39
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 52
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2516,6 +4196,15 @@ children:
                 children:
                   - type: "text"
                     value: "GitHub"
+                    position:
+                      start:
+                        line: 3
+                        column: 25
+                        offset: 76
+                      end:
+                        line: 3
+                        column: 31
+                        offset: 82
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 88
@@ -2523,6 +4212,15 @@ children:
             children:
               - type: "text"
                 value: "This is GitHub, your hub for Git repos.\\n"
+                position:
+                  start:
+                    line: 3
+                    column: 37
+                    offset: 88
+                  end:
+                    line: 4
+                    column: 1
+                    offset: 128
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2539,6 +4237,15 @@ children:
                 children:
                   - type: "text"
                     value: "Gitlab"
+                    position:
+                      start:
+                        line: 4
+                        column: 4
+                        offset: 131
+                      end:
+                        line: 4
+                        column: 10
+                        offset: 137
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 142
@@ -2546,6 +4253,15 @@ children:
             children:
               - type: "text"
                 value: "Alternative to GitHub\\n"
+                position:
+                  start:
+                    line: 4
+                    column: 15
+                    offset: 142
+                  end:
+                    line: 5
+                    column: 1
+                    offset: 164
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2562,6 +4278,15 @@ children:
                 children:
                   - type: "text"
                     value: "Sourcehut"
+                    position:
+                      start:
+                        line: 5
+                        column: 4
+                        offset: 167
+                      end:
+                        line: 5
+                        column: 13
+                        offset: 176
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 181
@@ -2570,6 +4295,15 @@ children:
               - type: "text"
                 value: "Another alternative to GitHub that primarily uses email-based
                   workflows.\\n"
+                position:
+                  start:
+                    line: 5
+                    column: 18
+                    offset: 181
+                  end:
+                    line: 6
+                    column: 1
+                    offset: 254
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2586,6 +4320,15 @@ children:
                 children:
                   - type: "text"
                     value: "Codeberg"
+                    position:
+                      start:
+                        line: 6
+                        column: 4
+                        offset: 257
+                      end:
+                        line: 6
+                        column: 12
+                        offset: 265
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 270
@@ -2597,6 +4340,15 @@ children:
                 children:
                   - type: "text"
                     value: "ANOTHER ALTERNATIVE"
+                    position:
+                      start:
+                        line: 6
+                        column: 18
+                        offset: 271
+                      end:
+                        line: 6
+                        column: 37
+                        offset: 290
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -2617,6 +4369,15 @@ children:
                     children:
                       - type: "text"
                         value: "self-hosting Git server"
+                        position:
+                          start:
+                            line: 7
+                            column: 5
+                            offset: 296
+                          end:
+                            line: 7
+                            column: 28
+                            offset: 319
           - type: "paragraph"
             affiliated: {}
             contentsBegin: 325
@@ -2632,6 +4393,15 @@ children:
                     children:
                       - type: "text"
                         value: "The ultimate Git solution for privacy-oriented individuals!"
+                        position:
+                          start:
+                            line: 7
+                            column: 36
+                            offset: 327
+                          end:
+                            line: 7
+                            column: 95
+                            offset: 386
 `;
 
 exports[`org/parser list list after paragraph 1`] = `
@@ -2646,6 +4416,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
   - type: "plain-list"
     affiliated: {}
     indent: 0
@@ -2668,6 +4447,15 @@ children:
             children:
               - type: "text"
                 value: "list"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 8
+                  end:
+                    line: 2
+                    column: 7
+                    offset: 12
 `;
 
 exports[`org/parser list list inside quite inside list 1`] = `
@@ -2697,6 +4485,15 @@ children:
             children:
               - type: "text"
                 value: "list 1\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 10
           - type: "quote-block"
             affiliated: {}
             contentsBegin: 26
@@ -2724,6 +4521,15 @@ children:
                         children:
                           - type: "text"
                             value: "list 2\\n"
+                            position:
+                              start:
+                                line: 4
+                                column: 5
+                                offset: 30
+                              end:
+                                line: 5
+                                column: 1
+                                offset: 37
 `;
 
 exports[`org/parser list long blocks in lists 1`] = `
@@ -2753,10 +4559,28 @@ children:
             children:
               - type: "text"
                 value: "list\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 8
           - type: "src-block"
             affiliated: {}
             language: "c"
             value: "  x\\n\\n\\n  y\\n"
+            position:
+              start:
+                line: 4
+                column: 1
+                offset: 24
+              end:
+                line: 8
+                column: 1
+                offset: 34
 `;
 
 exports[`org/parser list long drawer in list 1`] = `
@@ -2786,6 +4610,15 @@ children:
             children:
               - type: "text"
                 value: "list\\n"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 3
+                    column: 1
+                    offset: 8
           - type: "drawer"
             affiliated: {}
             name: "DRAWER"
@@ -2799,6 +4632,15 @@ children:
                 children:
                   - type: "text"
                     value: "  x\\n"
+                    position:
+                      start:
+                        line: 4
+                        column: 1
+                        offset: 19
+                      end:
+                        line: 5
+                        column: 1
+                        offset: 23
               - type: "paragraph"
                 affiliated: {}
                 contentsBegin: 25
@@ -2806,6 +4648,15 @@ children:
                 children:
                   - type: "text"
                     value: "  y\\n"
+                    position:
+                      start:
+                        line: 7
+                        column: 1
+                        offset: 25
+                      end:
+                        line: 8
+                        column: 1
+                        offset: 29
 `;
 
 exports[`org/parser list nested lists 1`] = `
@@ -2835,6 +4686,15 @@ children:
             children:
               - type: "text"
                 value: "there\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 8
           - type: "plain-list"
             affiliated: {}
             indent: 2
@@ -2857,6 +4717,15 @@ children:
                     children:
                       - type: "text"
                         value: "nested\\n"
+                        position:
+                          start:
+                            line: 2
+                            column: 5
+                            offset: 12
+                          end:
+                            line: 3
+                            column: 1
+                            offset: 19
               - type: "list-item"
                 indent: 2
                 bullet: "- "
@@ -2872,6 +4741,15 @@ children:
                     children:
                       - type: "text"
                         value: "list"
+                        position:
+                          start:
+                            line: 3
+                            column: 5
+                            offset: 23
+                          end:
+                            line: 3
+                            column: 9
+                            offset: 27
 `;
 
 exports[`org/parser list ordered list 1`] = `
@@ -2901,6 +4779,15 @@ children:
             children:
               - type: "text"
                 value: "one\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 4
+                    offset: 3
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 7
       - type: "list-item"
         indent: 0
         bullet: "2. "
@@ -2916,6 +4803,15 @@ children:
             children:
               - type: "text"
                 value: "two"
+                position:
+                  start:
+                    line: 2
+                    column: 4
+                    offset: 10
+                  end:
+                    line: 2
+                    column: 7
+                    offset: 13
 `;
 
 exports[`org/parser list single-item list 1`] = `
@@ -2945,6 +4841,15 @@ children:
             children:
               - type: "text"
                 value: "hi"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 1
+                    column: 5
+                    offset: 4
 `;
 
 exports[`org/parser list two empty lines breaking list 1`] = `
@@ -2974,6 +4879,15 @@ children:
             children:
               - type: "text"
                 value: "list1\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 8
   - type: "plain-list"
     affiliated: {}
     indent: 0
@@ -2996,6 +4910,15 @@ children:
             children:
               - type: "text"
                 value: "list 2"
+                position:
+                  start:
+                    line: 4
+                    column: 3
+                    offset: 12
+                  end:
+                    line: 4
+                    column: 9
+                    offset: 18
 `;
 
 exports[`org/parser list two-item list 1`] = `
@@ -3025,6 +4948,15 @@ children:
             children:
               - type: "text"
                 value: "hi\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 5
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -3040,6 +4972,15 @@ children:
             children:
               - type: "text"
                 value: "there"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 7
+                  end:
+                    line: 2
+                    column: 8
+                    offset: 12
 `;
 
 exports[`org/parser lowercase custom drawer 1`] = `
@@ -3060,12 +5001,30 @@ children:
         children:
           - type: "text"
             value: "hello "
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 11
+              end:
+                line: 2
+                column: 7
+                offset: 17
           - type: "italic"
             contentsBegin: 18
             contentsEnd: 23
             children:
               - type: "text"
                 value: "there"
+                position:
+                  start:
+                    line: 2
+                    column: 8
+                    offset: 18
+                  end:
+                    line: 2
+                    column: 13
+                    offset: 23
 `;
 
 exports[`org/parser lowercase property drawer 1`] = `
@@ -3089,6 +5048,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "property-drawer"
         contentsBegin: 24
         contentsEnd: 57
@@ -3096,6 +5064,15 @@ children:
           - type: "node-property"
             key: "created"
             value: "[2019-03-13 Wed 23:57]"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 24
+              end:
+                line: 4
+                column: 1
+                offset: 57
 `;
 
 exports[`org/parser multiline \\( \\) fragment 1`] = `
@@ -3111,6 +5088,15 @@ children:
       - type: "latex-fragment"
         value: "\\\\(2\\n2\\n2\\n2\\\\)"
         contents: "2\\n2\\n2\\n2"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 4
+            offset: 11
 `;
 
 exports[`org/parser multiline \\[ \\] fragment 1`] = `
@@ -3126,6 +5112,15 @@ children:
       - type: "latex-fragment"
         value: "\\\\[2\\n2\\n2\\n2\\\\]"
         contents: "2\\n2\\n2\\n2"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 4
+            offset: 11
 `;
 
 exports[`org/parser multiline latex fragment (3 lines) 1`] = `
@@ -3141,6 +5136,15 @@ children:
       - type: "latex-fragment"
         value: "$$2\\n2\\n2$$"
         contents: "2\\n2\\n2"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 3
+            column: 4
+            offset: 9
 `;
 
 exports[`org/parser multiline latex fragment (4 lines) 1`] = `
@@ -3156,6 +5160,15 @@ children:
       - type: "latex-fragment"
         value: "$$2\\n2\\n2\\n2$$"
         contents: "2\\n2\\n2\\n2"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 4
+            offset: 11
 `;
 
 exports[`org/parser multiline latex fragment 1`] = `
@@ -3171,6 +5184,15 @@ children:
       - type: "latex-fragment"
         value: "$$2+\\n2$$"
         contents: "2+\\n2"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 4
+            offset: 8
 `;
 
 exports[`org/parser multiline single-$ fragment 1`] = `
@@ -3185,11 +5207,38 @@ children:
     children:
       - type: "text"
         value: "hello "
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
       - type: "latex-fragment"
         value: "$2\\n2\\n2\\n2$"
         contents: "2\\n2\\n2\\n2"
+        position:
+          start:
+            line: 1
+            column: 7
+            offset: 6
+          end:
+            line: 4
+            column: 3
+            offset: 15
       - type: "text"
         value: " world"
+        position:
+          start:
+            line: 4
+            column: 3
+            offset: 15
+          end:
+            line: 4
+            column: 9
+            offset: 21
 `;
 
 exports[`org/parser non-closing diary sexp 1`] = `
@@ -3200,6 +5249,15 @@ children:
   - type: "diary-sexp"
     affiliated: {}
     value: "%%(I am still a diary-sexp"
+    position:
+      start:
+        line: 1
+        column: 1
+        offset: 0
+      end:
+        line: 1
+        column: 27
+        offset: 26
 `;
 
 exports[`org/parser non-dual keyword inside paragraph 1`] = `
@@ -3214,6 +5272,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n#+BLAH[hi]: heh\\nhi\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 4
+            column: 1
+            offset: 25
 `;
 
 exports[`org/parser paragraph split by empty line 1`] = `
@@ -3228,6 +5295,15 @@ children:
     children:
       - type: "text"
         value: "a1\\na2\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 3
+            column: 1
+            offset: 6
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 7
@@ -3235,6 +5311,15 @@ children:
     children:
       - type: "text"
         value: "b"
+        position:
+          start:
+            line: 4
+            column: 1
+            offset: 7
+          end:
+            line: 4
+            column: 2
+            offset: 8
 `;
 
 exports[`org/parser planning fake planning 1`] = `
@@ -3258,6 +5343,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled: null
         deadline: null
@@ -3285,6 +5379,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "property-drawer"
         contentsBegin: 24
         contentsEnd: 24
@@ -3296,6 +5399,15 @@ children:
         children:
           - type: "text"
             value: "CLOSED: "
+            position:
+              start:
+                line: 4
+                column: 1
+                offset: 30
+              end:
+                line: 4
+                column: 9
+                offset: 38
           - type: "timestamp"
             timestampType: "inactive"
             rawValue: "[2021-05-31 Mon]"
@@ -3306,8 +5418,26 @@ children:
               hour: null
               minute: null
             end: null
+            position:
+              start:
+                line: 4
+                column: 9
+                offset: 38
+              end:
+                line: 4
+                column: 25
+                offset: 54
           - type: "text"
             value: "\\nthis is paragraph"
+            position:
+              start:
+                line: 4
+                column: 25
+                offset: 54
+              end:
+                line: 5
+                column: 18
+                offset: 72
 `;
 
 exports[`org/parser planning fake planning over multiple lines 1`] = `
@@ -3331,6 +5461,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled: null
         deadline: null
@@ -3345,6 +5484,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 9
+              offset: 19
+            end:
+              line: 2
+              column: 25
+              offset: 35
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 36
@@ -3352,6 +5500,15 @@ children:
         children:
           - type: "text"
             value: "SCHEDULED: "
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 36
+              end:
+                line: 3
+                column: 12
+                offset: 47
           - type: "timestamp"
             timestampType: "inactive"
             rawValue: "[2021-05-31 Mon]"
@@ -3362,8 +5519,26 @@ children:
               hour: null
               minute: null
             end: null
+            position:
+              start:
+                line: 3
+                column: 12
+                offset: 47
+              end:
+                line: 3
+                column: 28
+                offset: 63
           - type: "text"
             value: "\\nthis is paragraph"
+            position:
+              start:
+                line: 3
+                column: 28
+                offset: 63
+              end:
+                line: 4
+                column: 18
+                offset: 81
 `;
 
 exports[`org/parser planning mixed good and fake planning 1`] = `
@@ -3387,6 +5562,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled:
           type: "timestamp"
@@ -3399,6 +5583,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 20
+              offset: 30
+            end:
+              line: 2
+              column: 36
+              offset: 46
         deadline: null
         closed: null
 `;
@@ -3424,6 +5617,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled:
           type: "timestamp"
@@ -3436,6 +5638,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 43
+              offset: 53
+            end:
+              line: 2
+              column: 59
+              offset: 69
         deadline:
           type: "timestamp"
           timestampType: "inactive"
@@ -3447,6 +5658,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 70
+              offset: 80
+            end:
+              line: 2
+              column: 86
+              offset: 96
         closed:
           type: "timestamp"
           timestampType: "inactive"
@@ -3458,6 +5678,15 @@ children:
             hour: 23
             minute: 48
           end: null
+          position:
+            start:
+              line: 2
+              column: 9
+              offset: 19
+            end:
+              line: 2
+              column: 31
+              offset: 41
 `;
 
 exports[`org/parser planning paragraph after planning 1`] = `
@@ -3481,6 +5710,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled: null
         deadline: null
@@ -3495,6 +5733,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 9
+              offset: 19
+            end:
+              line: 2
+              column: 25
+              offset: 35
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 36
@@ -3502,6 +5749,15 @@ children:
         children:
           - type: "text"
             value: "this is paragraph"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 36
+              end:
+                line: 3
+                column: 18
+                offset: 53
 `;
 
 exports[`org/parser planning planning before property drawer 1`] = `
@@ -3525,6 +5781,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "planning"
         scheduled: null
         deadline: null
@@ -3539,6 +5804,15 @@ children:
             hour: null
             minute: null
           end: null
+          position:
+            start:
+              line: 2
+              column: 9
+              offset: 19
+            end:
+              line: 2
+              column: 25
+              offset: 35
       - type: "property-drawer"
         contentsBegin: 49
         contentsEnd: 49
@@ -3550,6 +5824,15 @@ children:
         children:
           - type: "text"
             value: "this is paragraph"
+            position:
+              start:
+                line: 5
+                column: 1
+                offset: 55
+              end:
+                line: 5
+                column: 18
+                offset: 72
 `;
 
 exports[`org/parser property drawer + section 1`] = `
@@ -3573,6 +5856,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "property-drawer"
         contentsBegin: 24
         contentsEnd: 57
@@ -3580,6 +5872,15 @@ children:
           - type: "node-property"
             key: "CREATED"
             value: "[2019-03-13 Wed 23:57]"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 24
+              end:
+                line: 4
+                column: 1
+                offset: 57
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 63
@@ -3587,6 +5888,15 @@ children:
         children:
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 5
+                column: 1
+                offset: 63
+              end:
+                line: 5
+                column: 6
+                offset: 68
 `;
 
 exports[`org/parser property drawer 1`] = `
@@ -3610,6 +5920,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 11
+                offset: 10
       - type: "property-drawer"
         contentsBegin: 24
         contentsEnd: 57
@@ -3617,6 +5936,15 @@ children:
           - type: "node-property"
             key: "CREATED"
             value: "[2019-03-13 Wed 23:57]"
+            position:
+              start:
+                line: 3
+                column: 1
+                offset: 24
+              end:
+                line: 4
+                column: 1
+                offset: 57
 `;
 
 exports[`org/parser section empty lines before first section 1`] = `
@@ -3631,6 +5959,15 @@ children:
     children:
       - type: "text"
         value: "hi"
+        position:
+          start:
+            line: 3
+            column: 1
+            offset: 2
+          end:
+            line: 3
+            column: 3
+            offset: 4
 `;
 
 exports[`org/parser section first top-level headline after list 1`] = `
@@ -3660,6 +5997,15 @@ children:
             children:
               - type: "text"
                 value: "list\\n"
+                position:
+                  start:
+                    line: 1
+                    column: 3
+                    offset: 2
+                  end:
+                    line: 2
+                    column: 1
+                    offset: 7
   - type: "section"
     contentsBegin: 7
     contentsEnd: 17
@@ -3676,6 +6022,15 @@ children:
         children:
           - type: "text"
             value: "headline"
+            position:
+              start:
+                line: 2
+                column: 3
+                offset: 9
+              end:
+                line: 2
+                column: 11
+                offset: 17
 `;
 
 exports[`org/parser section initial section 1`] = `
@@ -3690,6 +6045,15 @@ children:
     children:
       - type: "text"
         value: "hello\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 6
   - type: "section"
     contentsBegin: 6
     contentsEnd: 10
@@ -3706,6 +6070,15 @@ children:
         children:
           - type: "text"
             value: "hi"
+            position:
+              start:
+                line: 2
+                column: 3
+                offset: 8
+              end:
+                line: 2
+                column: 5
+                offset: 10
 `;
 
 exports[`org/parser section section in headline 1`] = `
@@ -3729,6 +6102,15 @@ children:
         children:
           - type: "text"
             value: "hello"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 8
+                offset: 7
       - type: "paragraph"
         affiliated: {}
         contentsBegin: 8
@@ -3736,6 +6118,15 @@ children:
         children:
           - type: "text"
             value: "this is section"
+            position:
+              start:
+                line: 2
+                column: 1
+                offset: 8
+              end:
+                line: 2
+                column: 16
+                offset: 23
 `;
 
 exports[`org/parser section single-line section 1`] = `
@@ -3750,6 +6141,15 @@ children:
     children:
       - type: "text"
         value: "hi"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 3
+            offset: 2
 `;
 
 exports[`org/parser single asterisk 1`] = `
@@ -3764,6 +6164,15 @@ children:
     children:
       - type: "text"
         value: "text\\n"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 2
+            column: 1
+            offset: 5
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 5
@@ -3771,6 +6180,15 @@ children:
     children:
       - type: "text"
         value: "*\\n"
+        position:
+          start:
+            line: 2
+            column: 1
+            offset: 5
+          end:
+            line: 3
+            column: 1
+            offset: 7
   - type: "paragraph"
     affiliated: {}
     contentsBegin: 8
@@ -3778,6 +6196,15 @@ children:
     children:
       - type: "text"
         value: "more text\\n"
+        position:
+          start:
+            line: 4
+            column: 1
+            offset: 8
+          end:
+            line: 5
+            column: 1
+            offset: 18
 `;
 
 exports[`org/parser subscript after subscript 1`] = `
@@ -3792,18 +6219,45 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 2
         contentsEnd: 4
         children:
           - type: "text"
             value: "12"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 5
+                offset: 4
       - type: "subscript"
         contentsBegin: 5
         contentsEnd: 7
         children:
           - type: "text"
             value: "22"
+            position:
+              start:
+                line: 1
+                column: 6
+                offset: 5
+              end:
+                line: 1
+                column: 8
+                offset: 7
 `;
 
 exports[`org/parser subscript after superscript 1`] = `
@@ -3818,18 +6272,45 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 2
         contentsEnd: 4
         children:
           - type: "text"
             value: "12"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 5
+                offset: 4
       - type: "subscript"
         contentsBegin: 5
         contentsEnd: 7
         children:
           - type: "text"
             value: "22"
+            position:
+              start:
+                line: 1
+                column: 6
+                offset: 5
+              end:
+                line: 1
+                column: 8
+                offset: 7
 `;
 
 exports[`org/parser subscript braces 1`] = `
@@ -3844,12 +6325,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 3
         contentsEnd: 4
         children:
           - type: "text"
             value: "+"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 5
+                offset: 4
 `;
 
 exports[`org/parser subscript multiple nesting groups 1`] = `
@@ -3864,12 +6363,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 3
         contentsEnd: 25
         children:
           - type: "text"
             value: "hello{there}and{there}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 26
+                offset: 25
 `;
 
 exports[`org/parser subscript nested braces 1`] = `
@@ -3884,12 +6401,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 3
         contentsEnd: 6
         children:
           - type: "text"
             value: "{x}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 7
+                offset: 6
 `;
 
 exports[`org/parser subscript nested braces, 3 levels 1`] = `
@@ -3904,12 +6439,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 3
         contentsEnd: 19
         children:
           - type: "text"
             value: "hello{hi{there}}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 20
+                offset: 19
 `;
 
 exports[`org/parser subscript no superscript begginning of line 1`] = `
@@ -3924,6 +6477,15 @@ children:
     children:
       - type: "text"
         value: "_hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
 `;
 
 exports[`org/parser subscript no superscript multiple 2-level nesting groups 1`] = `
@@ -3938,6 +6500,15 @@ children:
     children:
       - type: "text"
         value: "H_{hello{there{}}and{there}}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser subscript no superscript post whitespace 1`] = `
@@ -3952,6 +6523,15 @@ children:
     children:
       - type: "text"
         value: "hello_ there"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser subscript no superscript pre whitespace 1`] = `
@@ -3966,6 +6546,15 @@ children:
     children:
       - type: "text"
         value: "hello _there"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser subscript no superscript too many nested braces 1`] = `
@@ -3980,6 +6569,15 @@ children:
     children:
       - type: "text"
         value: "H_{hello{hi{there{hello?}}}}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser subscript no superscript unbalanced braces 1`] = `
@@ -3994,6 +6592,15 @@ children:
     children:
       - type: "text"
         value: "H_{{+}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
 `;
 
 exports[`org/parser subscript simple 1`] = `
@@ -4008,12 +6615,30 @@ children:
     children:
       - type: "text"
         value: "hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 6
+            offset: 5
       - type: "subscript"
         contentsBegin: 6
         contentsEnd: 11
         children:
           - type: "text"
             value: "world"
+            position:
+              start:
+                line: 1
+                column: 7
+                offset: 6
+              end:
+                line: 1
+                column: 12
+                offset: 11
 `;
 
 exports[`org/parser subscript spaces in braces 1`] = `
@@ -4028,12 +6653,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 3
         contentsEnd: 14
         children:
           - type: "text"
             value: "hello world"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 15
+                offset: 14
 `;
 
 exports[`org/parser subscript trailing _ 1`] = `
@@ -4048,14 +6691,41 @@ children:
     children:
       - type: "text"
         value: "f"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "subscript"
         contentsBegin: 2
         contentsEnd: 3
         children:
           - type: "text"
             value: "f"
+            position:
+              start:
+                line: 1
+                column: 3
+                offset: 2
+              end:
+                line: 1
+                column: 4
+                offset: 3
       - type: "text"
         value: "_"
+        position:
+          start:
+            line: 1
+            column: 4
+            offset: 3
+          end:
+            line: 1
+            column: 5
+            offset: 4
 `;
 
 exports[`org/parser superscript braces 1`] = `
@@ -4070,12 +6740,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 3
         contentsEnd: 4
         children:
           - type: "text"
             value: "+"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 5
+                offset: 4
 `;
 
 exports[`org/parser superscript multiple nesting groups 1`] = `
@@ -4090,12 +6778,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 3
         contentsEnd: 25
         children:
           - type: "text"
             value: "hello{there}and{there}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 26
+                offset: 25
 `;
 
 exports[`org/parser superscript nested braces 1`] = `
@@ -4110,12 +6816,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 3
         contentsEnd: 6
         children:
           - type: "text"
             value: "{x}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 7
+                offset: 6
 `;
 
 exports[`org/parser superscript nested braces, 3 levels 1`] = `
@@ -4130,12 +6854,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 3
         contentsEnd: 19
         children:
           - type: "text"
             value: "hello{hi{there}}"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 20
+                offset: 19
 `;
 
 exports[`org/parser superscript no superscript begginning of line 1`] = `
@@ -4150,6 +6892,15 @@ children:
     children:
       - type: "text"
         value: "^hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
 `;
 
 exports[`org/parser superscript no superscript multiple 2-level nesting groups 1`] = `
@@ -4164,6 +6915,15 @@ children:
     children:
       - type: "text"
         value: "H^{hello{there{}}and{there}}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser superscript no superscript post whitespace 1`] = `
@@ -4178,6 +6938,15 @@ children:
     children:
       - type: "text"
         value: "hello^ there"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser superscript no superscript pre whitespace 1`] = `
@@ -4192,6 +6961,15 @@ children:
     children:
       - type: "text"
         value: "hello ^there"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 13
+            offset: 12
 `;
 
 exports[`org/parser superscript no superscript too many nested braces 1`] = `
@@ -4206,6 +6984,15 @@ children:
     children:
       - type: "text"
         value: "H^{hello{hi{there{hello?}}}}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser superscript no superscript unbalanced braces 1`] = `
@@ -4220,6 +7007,15 @@ children:
     children:
       - type: "text"
         value: "H^{{+}"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 7
+            offset: 6
 `;
 
 exports[`org/parser superscript simple 1`] = `
@@ -4234,12 +7030,30 @@ children:
     children:
       - type: "text"
         value: "hello"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 6
+            offset: 5
       - type: "superscript"
         contentsBegin: 6
         contentsEnd: 11
         children:
           - type: "text"
             value: "world"
+            position:
+              start:
+                line: 1
+                column: 7
+                offset: 6
+              end:
+                line: 1
+                column: 12
+                offset: 11
 `;
 
 exports[`org/parser superscript spaces in braces 1`] = `
@@ -4254,12 +7068,30 @@ children:
     children:
       - type: "text"
         value: "H"
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 2
+            offset: 1
       - type: "superscript"
         contentsBegin: 3
         contentsEnd: 14
         children:
           - type: "text"
             value: "hello world"
+            position:
+              start:
+                line: 1
+                column: 4
+                offset: 3
+              end:
+                line: 1
+                column: 15
+                offset: 14
 `;
 
 exports[`org/parser table 1`] = `
@@ -4284,12 +7116,30 @@ children:
             children:
               - type: "text"
                 value: "head1"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 2
+                    column: 8
+                    offset: 8
           - type: "table-cell"
             contentsBegin: 12
             contentsEnd: 17
             children:
               - type: "text"
                 value: "head2"
+                position:
+                  start:
+                    line: 2
+                    column: 12
+                    offset: 12
+                  end:
+                    line: 2
+                    column: 17
+                    offset: 17
       - type: "table-row"
         rowType: "rule"
         contentsBegin: 21
@@ -4306,12 +7156,30 @@ children:
             children:
               - type: "text"
                 value: "value1"
+                position:
+                  start:
+                    line: 4
+                    column: 3
+                    offset: 41
+                  end:
+                    line: 4
+                    column: 9
+                    offset: 47
           - type: "table-cell"
             contentsBegin: 50
             contentsEnd: 56
             children:
               - type: "text"
                 value: "value2"
+                position:
+                  start:
+                    line: 4
+                    column: 12
+                    offset: 50
+                  end:
+                    line: 4
+                    column: 18
+                    offset: 56
 `;
 
 exports[`org/parser table with format 1`] = `
@@ -4336,6 +7204,15 @@ children:
             children:
               - type: "text"
                 value: "1"
+                position:
+                  start:
+                    line: 2
+                    column: 3
+                    offset: 3
+                  end:
+                    line: 2
+                    column: 4
+                    offset: 4
       - type: "table-row"
         rowType: "standard"
         contentsBegin: 8
@@ -4347,6 +7224,15 @@ children:
             children:
               - type: "text"
                 value: "2"
+                position:
+                  start:
+                    line: 3
+                    column: 3
+                    offset: 9
+                  end:
+                    line: 3
+                    column: 4
+                    offset: 10
 `;
 
 exports[`org/parser table.el table 1`] = `
@@ -4389,6 +7275,15 @@ children:
           hour: null
           minute: null
         end: null
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 17
+            offset: 16
 `;
 
 exports[`org/parser timestamps active-range 1`] = `
@@ -4416,6 +7311,15 @@ children:
           day: 9
           hour: null
           minute: null
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 35
+            offset: 34
 `;
 
 exports[`org/parser timestamps inactive 1`] = `
@@ -4438,6 +7342,15 @@ children:
           hour: null
           minute: null
         end: null
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 17
+            offset: 16
 `;
 
 exports[`org/parser timestamps inactive-range 1`] = `
@@ -4465,6 +7378,15 @@ children:
           day: 8
           hour: null
           minute: null
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 35
+            offset: 34
 `;
 
 exports[`org/parser timestamps time range 1`] = `
@@ -4492,6 +7414,15 @@ children:
           day: 7
           hour: 20
           minute: 38
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 29
+            offset: 28
 `;
 
 exports[`org/parser timestamps with time 1`] = `
@@ -4514,4 +7445,13 @@ children:
           hour: 19
           minute: 36
         end: null
+        position:
+          start:
+            line: 1
+            column: 1
+            offset: 0
+          end:
+            line: 1
+            column: 23
+            offset: 22
 `;

--- a/packages/uniorg-parse/src/parse-options.ts
+++ b/packages/uniorg-parse/src/parse-options.ts
@@ -25,6 +25,10 @@ export interface ParseOptions {
    * matching. Corresponds to `org-match-sexp-depth` in Emacs.
    */
   matchSexpDepth: number;
+  /**
+   * Add begin/end properties to primitive nodes
+   */
+  positions: boolean;
 }
 
 export const defaultOptions: ParseOptions = {
@@ -167,4 +171,5 @@ export const defaultOptions: ParseOptions = {
     'do',
   ],
   matchSexpDepth: 3,
+  positions: true,
 };

--- a/packages/uniorg-parse/src/parse-options.ts
+++ b/packages/uniorg-parse/src/parse-options.ts
@@ -171,5 +171,5 @@ export const defaultOptions: ParseOptions = {
     'do',
   ],
   matchSexpDepth: 3,
-  positions: true,
+  position: true,
 };

--- a/packages/uniorg-parse/src/parse-options.ts
+++ b/packages/uniorg-parse/src/parse-options.ts
@@ -28,7 +28,7 @@ export interface ParseOptions {
   /**
    * Add begin/end properties to primitive nodes
    */
-  positions: boolean;
+  position: boolean;
 }
 
 export const defaultOptions: ParseOptions = {

--- a/packages/uniorg-parse/src/parse-options.ts
+++ b/packages/uniorg-parse/src/parse-options.ts
@@ -26,7 +26,7 @@ export interface ParseOptions {
    */
   matchSexpDepth: number;
   /**
-   * Add begin/end properties to primitive nodes
+   * Add `position` information to nodes
    */
   position: boolean;
 }

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -1586,7 +1586,7 @@ class Parser {
     }
     const value = getOrgEntity(m.groups!.value1 ?? m.groups!.value2);
     if (!value) return null;
-    const end = begin + m[0].length;
+    const end = this.r.offset();
     return u('entity', {
       useBrackets: hasBrackets,
       ...value,

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -448,9 +448,9 @@ class Parser {
 
     // handle text after the last object
     const text = this.r.rest();
-    const [begin, end] = [this.r.offset(), this.r.offset() + text.length];
-
+    const begin = this.r.offset();
     this.r.advance(text.length);
+    const end = this.r.offset();
     if (text.trim().length) {
       objects.push(u('text', { value: text, ...this.getPosition(begin, end) }));
     }

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -1044,11 +1044,9 @@ class Parser {
 
   private parseClock(): Clock {
     const begin = this.r.offset();
-    const parsedClock = this.r.forceMatch(/^[ \t]*CLOCK:[ \t]*/);
-    this.r.advance(parsedClock);
+    this.r.advance(this.r.forceMatch(/^[ \t]*CLOCK:[ \t]*/));
     const value = this.parseTimestamp();
-
-    const end = begin + parsedClock.input.length;
+    const end = this.r.offset();
     this.r.advance(this.r.match(/^[ \t]+=>[ \t]*/));
     const durationM = this.r.advance(this.r.lookingAt(/^(\S+)[ \t]*$/m));
     const duration = durationM ? durationM[1] : null;

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -427,9 +427,7 @@ class Parser {
         // parse text before object
         const value = this.r.substring(prevEnd, objectBegin);
         const end = prevEnd + value.length;
-        objects.push(
-          u('text', { value, position: this.getPosition(prevEnd, end) })
-        );
+        objects.push(u('text', { value, ...this.getPosition(prevEnd, end) }));
       }
 
       // @ts-expect-error contentsBegin is not defined for "literals"
@@ -455,9 +453,7 @@ class Parser {
 
     this.r.advance(text.length);
     if (text.trim().length) {
-      objects.push(
-        u('text', { value: text, position: this.getPosition(begin, end) })
-      );
+      objects.push(u('text', { value: text, ...this.getPosition(begin, end) }));
     }
 
     return objects;
@@ -780,7 +776,7 @@ class Parser {
 
     return u('comment', {
       value: value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -800,7 +796,7 @@ class Parser {
     return u('fixed-width', {
       affiliated,
       value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -817,7 +813,7 @@ class Parser {
     return u('comment-block', {
       affiliated,
       value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -850,7 +846,7 @@ class Parser {
       affiliated,
       language,
       value,
-      position: this.getPosition(contentsBegin, contentsEnd),
+      ...this.getPosition(contentsBegin, contentsEnd),
     });
   }
 
@@ -867,7 +863,7 @@ class Parser {
     return u('example-block', {
       affiliated,
       value,
-      position: this.getPosition(block.contentsBegin, block.contentsEnd),
+      ...this.getPosition(block.contentsBegin, block.contentsEnd),
     });
   }
 
@@ -900,7 +896,7 @@ class Parser {
       affiliated,
       backend,
       value,
-      position: this.getPosition(contentsBegin, contentsEnd),
+      ...this.getPosition(contentsBegin, contentsEnd),
     });
   }
 
@@ -998,7 +994,7 @@ class Parser {
       affiliated,
       key,
       value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1025,7 +1021,7 @@ class Parser {
     return u('latex-environment', {
       affiliated,
       value,
-      position: this.getPosition(beginOffset, endOffset),
+      ...this.getPosition(beginOffset, endOffset),
     });
   }
 
@@ -1066,7 +1062,7 @@ class Parser {
       value,
       duration,
       status,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1082,7 +1078,7 @@ class Parser {
     return u('node-property', {
       key,
       value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1213,7 +1209,7 @@ class Parser {
     return u('diary-sexp', {
       affiliated,
       value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1537,7 +1533,7 @@ class Parser {
     const contentsEnd = contentsBegin + m[4].length;
     this.r.resetOffset(contentsEnd + 1);
     const [begin, end] = this.getCurrentRange(value);
-    return u('code', { value, position: this.getPosition(begin, end) }, []);
+    return u('code', { value, ...this.getPosition(begin, end) }, []);
   }
 
   private parseVerbatim(): Verbatim | null {
@@ -1597,7 +1593,7 @@ class Parser {
     return u('entity', {
       useBrackets: hasBrackets,
       ...value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1655,7 +1651,7 @@ class Parser {
     return u('latex-fragment', {
       value,
       contents: contents ?? value,
-      position: this.getPosition(begin, end),
+      ...this.getPosition(begin, end),
     });
   }
 
@@ -1892,7 +1888,7 @@ class Parser {
       rawValue,
       start,
       end,
-      position: this.getPosition(begin, begin + rawValue.length),
+      ...this.getPosition(begin, begin + rawValue.length),
     });
   }
 
@@ -1948,11 +1944,11 @@ class Parser {
     return [this.r.offset(), this.r.offset() + val.length];
   }
 
-  private getPosition(begin: number, end: number): Position | undefined {
-    if (!this.options.positions) {
-      return;
+  private getPosition(begin: number, end: number): { position?: Position } {
+    if (!this.options.position) {
+      return {};
     }
-    return this.r.toPosition(begin, end);
+    return { position: this.r.toPosition(begin, end) };
   }
 }
 

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -755,9 +755,9 @@ class Parser {
   }
 
   private parseComment(): Comment {
+    const begin = this.r.offset();
     let valueLines = [];
     this.r.advance(this.r.forceLookingAt(/^[ \t]*# ?/));
-    const begin = this.r.offset();
 
     valueLines.push(this.r.advance(this.r.line()));
 

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -771,7 +771,7 @@ class Parser {
     if (value[value.length - 1] === '\n') {
       value = value.substring(0, value.length - 1);
     }
-    const end = begin + value.length;
+    const end = this.r.offset();
 
     return u('comment', {
       value: value,

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -426,8 +426,7 @@ class Parser {
       if (objectBegin !== prevEnd) {
         // parse text before object
         const value = this.r.substring(prevEnd, objectBegin);
-        const end = prevEnd + value.length;
-        objects.push(u('text', { value, ...this.getPosition(prevEnd, end) }));
+        objects.push(u('text', { value, ...this.getPosition(prevEnd, objectBegin) }));
       }
 
       // @ts-expect-error contentsBegin is not defined for "literals"

--- a/packages/uniorg-parse/src/reader.ts
+++ b/packages/uniorg-parse/src/reader.ts
@@ -1,4 +1,4 @@
-import { Point, Position } from 'unist';
+import type { Point, Position } from 'unist';
 import { VFile } from 'vfile';
 import { location } from 'vfile-location';
 

--- a/packages/uniorg-parse/src/reader.ts
+++ b/packages/uniorg-parse/src/reader.ts
@@ -1,3 +1,4 @@
+import { Point, Position } from 'unist';
 import { VFile } from 'vfile';
 import { location } from 'vfile-location';
 
@@ -165,5 +166,15 @@ export class Reader {
         this.#offset = narrow.prevOffset;
       }
     }
+  }
+  public toPoint(offset: number): Point {
+    return this.#location.toPoint(offset);
+  }
+
+  public toPosition(begin: number, end: number): Position {
+    return {
+      start: this.toPoint(begin),
+      end: this.toPoint(end),
+    };
   }
 }


### PR DESCRIPTION
I had no luck setting begin/end for the Timestamp object (since this type already has an end property, I could use a universal property name - contentsBegin/contentsEnd, if you don't mind).