### PR TITLE
fix(#57): fix whitespace entity parsing (\_<SPC>)

### DIFF
--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`org/parser \\_<SPC> 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 4
+children:
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 0
+    contentsEnd: 4
+    children:
+      - type: "entity"
+        useBrackets: false
+        name: "_ "
+        latex: "\\\\hspace*{0.5em}"
+        requireLatexMath: false
+        html: "&ensp;"
+        ascii: " "
+        latin1: " "
+        utf8: " "
+      - type: "text"
+        value: "a"
+`;
+
 exports[`org/parser affiliated keyword dual keywords 1`] = `
 type: "org-data"
 contentsBegin: 0

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -980,4 +980,7 @@ either $$ a=+\\sqrt{2} $$ or \\[ a=-\\sqrt{2} \\].`
 more text
 `
   );
+
+  // See https://github.com/rasendubi/uniorg/issues/57
+  itParses('\\_<SPC>', '\\_ a');
 });

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -1512,7 +1512,7 @@ class Parser {
     );
     if (!m) return null;
     const hasBrackets = m.groups!.brackets === '{}';
-    if (!hasBrackets) {
+    if (m.groups!.brackets && !hasBrackets) {
       // The brackets group is not brackets. That means it captured an
       // extra non-letter or a newline. Backoff, so it can be parsed
       // as text later.


### PR DESCRIPTION
The crash was caused by entity regex returning undefined for "brackets" group (because it only applies for value2 branch) and the code tried to backoff.

Fix by adding a guard against empty brackets group.

Fixes #57 