### PR TITLE
fix(#83): prevent crash when unexpected parameter is provided to export-block

### DIFF
--- a/.changeset/green-bees-matter.md
+++ b/.changeset/green-bees-matter.md
@@ -1,0 +1,9 @@
+---
+'uniorg-parse': patch
+---
+
+Prevent crash when export-block has unexpected parameters.
+
+When export-block was provided unexpected parameters, uniorg has thrown an exception and stopped parsing. org-element fails to parse export-block backend but otherwise continues to parse. We replicate the same behavior in Uniorg now.
+
+Fixes [#83](https://github.com/rasendubi/uniorg/issues/83).

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -214,6 +214,17 @@ children:
     value: "hi\\n"
 `;
 
+exports[`org/parser blocks export block with incorrect header 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 55
+children:
+  - type: "export-block"
+    affiliated: {}
+    backend: null
+    value: "Hi, there!\\n"
+`;
+
 exports[`org/parser blocks fake block 1`] = `
 type: "org-data"
 contentsBegin: 0

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -585,6 +585,19 @@ hi
 #+end_export`
     );
 
+    // Adding any parameter to export-block fails backend parsing in
+    // org-element, so the block is not exported. We're preserving
+    // this behavior in Uniorg.
+    //
+    // See https://github.com/rasendubi/uniorg/issues/83 for more
+    // information.
+    itParses(
+      'export block with incorrect header',
+      `#+begin_export html :hello blah
+Hi, there!
+#+end_export`
+    );
+
     itParses(
       'special block',
       `#+begin_blah

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -927,10 +927,10 @@ class Parser {
       return this.parseParagraph(affiliated);
     }
 
-    const headerM = this.r.forceMatch(
+    const headerM = this.r.match(
       /^[ \t]*#\+begin_export(?:[ \t]+(\S+))?[ \t]*$/im
     );
-    const backend = headerM[1] ?? null;
+    const backend = headerM?.[1] ?? null;
 
     const begin = this.r.offset();
     const contentsBegin = begin + this.r.line().length;


### PR DESCRIPTION

Fixes #83