### PR TITLE
feat(parse): add switches and params for src-block

### DIFF
--- a/.changeset/nasty-scissors-reply.md
+++ b/.changeset/nasty-scissors-reply.md
@@ -1,0 +1,5 @@
+---
+'uniorg-parse': minor
+---
+
+Add support for switches and parameters in src-blocks.

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -373,6 +373,19 @@ children:
     value: "hello\\n"
 `;
 
+exports[`org/parser blocks src block with switches and arguments 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 58
+children:
+  - type: "src-block"
+    affiliated: {}
+    language: "js"
+    switches: "+n 10"
+    parameters: ":exports none"
+    value: "const t = 10\\n"
+`;
+
 exports[`org/parser blocks src in list 1`] = `
 type: "org-data"
 contentsBegin: 0

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -373,16 +373,27 @@ children:
     value: "hello\\n"
 `;
 
-exports[`org/parser blocks src block with switches and arguments 1`] = `
+exports[`org/parser blocks src block with parameters 1`] = `
 type: "org-data"
 contentsBegin: 0
-contentsEnd: 58
+contentsEnd: 52
+children:
+  - type: "src-block"
+    affiliated: {}
+    language: "js"
+    parameters: ":exports none"
+    value: "const t = 10\\n"
+`;
+
+exports[`org/parser blocks src block with switches 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 44
 children:
   - type: "src-block"
     affiliated: {}
     language: "js"
     switches: "+n 10"
-    parameters: ":exports none"
     value: "const t = 10\\n"
 `;
 

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -44,6 +44,8 @@ children:
   - type: "src-block"
     affiliated:
       NAME: "hi"
+    switches: null
+    parameters: null
     value: ""
 `;
 
@@ -94,6 +96,8 @@ children:
     affiliated:
       NAME: "source"
     language: "org"
+    switches: null
+    parameters: null
     value: "some paragraph\\n"
 `;
 
@@ -128,6 +132,8 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "org"
+    switches: null
+    parameters: null
     value: "#+ escaped\\n"
 `;
 
@@ -158,6 +164,8 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "org"
+    switches: null
+    parameters: null
     value: ",,* two commas escaped\\n"
 `;
 
@@ -179,6 +187,8 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "c"
+    switches: null
+    parameters: null
     value: "*a = 0;\\n"
 `;
 
@@ -288,6 +298,8 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "org"
+    switches: null
+    parameters: null
     value: ",# nont escaped\\n"
 `;
 
@@ -299,6 +311,8 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "org"
+    switches: null
+    parameters: null
     value: "* not a headline;\\n"
 `;
 
@@ -370,6 +384,8 @@ contentsEnd: 27
 children:
   - type: "src-block"
     affiliated: {}
+    switches: null
+    parameters: null
     value: "hello\\n"
 `;
 
@@ -381,6 +397,7 @@ children:
   - type: "src-block"
     affiliated: {}
     language: "js"
+    switches: null
     parameters: ":exports none"
     value: "const t = 10\\n"
 `;
@@ -394,6 +411,20 @@ children:
     affiliated: {}
     language: "js"
     switches: "+n 10"
+    parameters: null
+    value: "const t = 10\\n"
+`;
+
+exports[`org/parser blocks src block with switches and parameters 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 58
+children:
+  - type: "src-block"
+    affiliated: {}
+    language: "js"
+    switches: "+n 10"
+    parameters: ":exports none"
     value: "const t = 10\\n"
 `;
 
@@ -426,6 +457,8 @@ children:
                 value: "example:\\n"
           - type: "src-block"
             affiliated: {}
+            switches: null
+            parameters: null
             value: "  blah\\n"
 `;
 
@@ -3224,6 +3257,8 @@ children:
           - type: "src-block"
             affiliated: {}
             language: "c"
+            switches: null
+            parameters: null
             value: "  x\\n\\n\\n  y\\n"
 `;
 

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -532,10 +532,18 @@ hello
   #+end_src`
     );
 
-    itParses.only(
-      'src block with switches and arguments',
+    itParses(
+      'src block with switches',
       `
-#+begin_src js +n 10 :exports none
+#+begin_src js +n 10
+const t = 10
+#+end_src`
+    );
+
+    itParses(
+      'src block with parameters',
+      `
+#+begin_src js :exports none
 const t = 10
 #+end_src`
     );

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -549,6 +549,14 @@ const t = 10
     );
 
     itParses(
+      'src block with switches and parameters',
+      `
+#+begin_src js +n 10 :exports none
+const t = 10
+#+end_src`
+    );
+
+    itParses(
       'quote block',
       `#+begin_quote
 hello

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -532,6 +532,14 @@ hello
   #+end_src`
     );
 
+    itParses.only(
+      'src block with switches and arguments',
+      `
+#+begin_src js +n 10 :exports none
+const t = 10
+#+end_src`
+    );
+
     itParses(
       'quote block',
       `#+begin_quote

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -906,7 +906,7 @@ class Parser {
       affiliated,
       language,
       switches: switches?.trim(),
-      parameters: parameters?.trim(),
+      parameters: parameters !== '' ? parameters?.trim() : undefined,
       value,
     });
   }

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -905,8 +905,9 @@ class Parser {
     return u('src-block', {
       affiliated,
       language,
-      switches: switches?.trim(),
-      parameters: parameters !== '' ? parameters?.trim() : undefined,
+      switches: switches?.trim() ?? null,
+      // using || to convert empty strings to null as well
+      parameters: parameters.trim() || null,
       value,
     });
   }

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -902,7 +902,13 @@ class Parser {
     this.parseEmptyLines();
     const _end = this.r.offset();
 
-    return u('src-block', { affiliated, language, value });
+    return u('src-block', {
+      affiliated,
+      language,
+      switches: switches?.trim(),
+      parameters: parameters?.trim(),
+      value,
+    });
   }
 
   private parseExampleBlock(


### PR DESCRIPTION
Exposes switches and parameters of the `src-block`, so we can reference these later in the pipeline.

Reason?
I depend on `:exports none` to prep some data behind the scenes, that I don't want to expose to the reader. 