### PR TITLE
feat: add options to uniorgStringify to customize handlers

### DIFF
--- a/.changeset/green-phones-love.md
+++ b/.changeset/green-phones-love.md
@@ -1,0 +1,7 @@
+---
+'uniorg-stringify': minor
+---
+
+Allow overriding handlers.
+
+`uniorgStringify` now accepts an optional handlers configuration.

--- a/packages/uniorg-stringify/README.md
+++ b/packages/uniorg-stringify/README.md
@@ -25,11 +25,11 @@ console.log(String(result)); //=> Some /emphasis/, *importance*, and ~code~.
 
 ## API
 
-### `processor().use(uniorgStringify)`
+### `processor().use(uniorgStringify[, options])`
 
 **uniorg** plugin to serialize uniast into string.
 
-### `stringify(uniast)`
+### `stringify(uniast[, options])`
 
 Convert uniorg AST into a string.
 
@@ -40,6 +40,23 @@ import { stringify } from 'uniorg-stringify/lib/stringify';
 stringify(parse(`* headline`));
 ```
 
+### `options`
+
+#### `handlers`
+Allow overriding rendering for any uniorg type. Each handler receives the node of the corresponding type and should return a string.
+
+For example to output bold emphasis with dollar signs instead of stars:
+```js
+const processor = unified()
+  .use(uniorgParse)
+  .use(uniorgStringify, {
+    handlers: {
+      'bold': (org, options) => {
+        return `$${stringify(org.children, options)}$`;
+      },
+    },
+  });
+```
 ## License
 
 [GNU General Public License v3.0 or later](./LICENSE)

--- a/packages/uniorg-stringify/src/__snapshots__/stringify.spec.ts.snap
+++ b/packages/uniorg-stringify/src/__snapshots__/stringify.spec.ts.snap
@@ -211,6 +211,16 @@ exports[`stringify footnotes starting on next line 1`] = `
 "
 `;
 
+exports[`stringify handlers allow handlers to return empty string to suppress output 1`] = `
+"hello,  world
+"
+`;
+
+exports[`stringify handlers allow handlers to return null to fallback to default processing 1`] = `
+"hello, +Dave+ world
+"
+`;
+
 exports[`stringify headline complex headline 1`] = `
 "* TODO [#A] COMMENT headline /italic/ title :some:tags:
 "

--- a/packages/uniorg-stringify/src/__snapshots__/stringify.spec.ts.snap
+++ b/packages/uniorg-stringify/src/__snapshots__/stringify.spec.ts.snap
@@ -143,6 +143,11 @@ exports[`stringify emphasis marks bold 1`] = `
 "
 `;
 
+exports[`stringify emphasis marks bold with custom char 1`] = `
+"$hello$
+"
+`;
+
 exports[`stringify emphasis marks emphasis 1`] = `
 "/Consider/ ~t*h*e~ *following* =example= +strike+
 "
@@ -216,6 +221,17 @@ exports[`stringify headline nested headline 1`] = `
 ** level 2
 * level 1
 *** level 3
+"
+`;
+
+exports[`stringify headline nested simple headlines separated by new-lines 1`] = `
+"* level 1
+
+** level 2
+
+*** level 3
+
+**** level 4
 "
 `;
 
@@ -394,6 +410,14 @@ exports[`stringify property drawer 1`] = `
 :PROPERTIES:
 :CREATED: [2019-03-13 Wed 23:57]
 :END:
+"
+`;
+
+exports[`stringify property drawer forced to lower-case 1`] = `
+"* headline
+:properties:
+:created: [2019-03-13 Wed 23:57]
+:end:
 "
 `;
 

--- a/packages/uniorg-stringify/src/index.ts
+++ b/packages/uniorg-stringify/src/index.ts
@@ -1,8 +1,11 @@
 import type { Node } from 'unist';
 import { stringify } from './stringify.js';
-import type { Options } from './stringify.js';
+import type { StringifyOptions } from './stringify.js';
 
-export function uniorgStringify(this: any, options: Options = {}) {
+export function uniorgStringify(
+  this: any,
+  options: Partial<StringifyOptions> = {}
+) {
   this.Compiler = (node: Node) => {
     return stringify(node, options);
   };

--- a/packages/uniorg-stringify/src/index.ts
+++ b/packages/uniorg-stringify/src/index.ts
@@ -1,8 +1,9 @@
 import type { Node } from 'unist';
 import { stringify } from './stringify.js';
+import type { Options } from './stringify.js';
 
-export function uniorgStringify(this: any) {
+export function uniorgStringify(this: any, options: Options = {}) {
   this.Compiler = (node: Node) => {
-    return stringify(node);
+    return stringify(node, options);
   };
 }

--- a/packages/uniorg-stringify/src/stringify.spec.ts
+++ b/packages/uniorg-stringify/src/stringify.spec.ts
@@ -497,4 +497,19 @@ some text
     'citation',
     `[cite/style:common prefix; prefix @key suffix; @key2; common suffix]`
   );
+
+  describe('handlers', () => {
+    test(
+      'allow handlers to return empty string to suppress output',
+      `hello, +Dave+ world`,
+      { handlers: { 'strike-through': () => '' } }
+    );
+
+    // This usage is currently not guaranteed and may change in the future.
+    test.skip(
+      'allow handlers to return null to fallback to default processing',
+      `hello, +Dave+ world`,
+      { handlers: { 'strike-through': () => null } }
+    );
+  });
 });

--- a/packages/uniorg-stringify/src/stringify.spec.ts
+++ b/packages/uniorg-stringify/src/stringify.spec.ts
@@ -1,12 +1,16 @@
 import { parse } from 'uniorg-parse/lib/parser';
 
-import { Options, stringify } from './stringify';
+import { StringifyOptions, stringify } from './stringify';
 
-const process = (input: string, options: Options) => {
+const process = (input: string, options: Partial<StringifyOptions>) => {
   return stringify(parse(input), options);
 };
 
-const test = (name: string, input: string, options: Options = {}) => {
+const test = (
+  name: string,
+  input: string,
+  options: Partial<StringifyOptions> = {}
+) => {
   it(name, () => {
     const result = process(input, options);
     expect(result).toMatchSnapshot();
@@ -17,7 +21,11 @@ const test = (name: string, input: string, options: Options = {}) => {
     expect(result2).toEqual(result1);
   });
 };
-test.skip = (name: string, input: string, options: Options = {}) => {
+test.skip = (
+  name: string,
+  input: string,
+  options: Partial<StringifyOptions> = {}
+) => {
   it.skip(name, () => {
     const result = process(input, options);
     expect(result).toMatchSnapshot();
@@ -28,7 +36,11 @@ test.skip = (name: string, input: string, options: Options = {}) => {
     expect(result2).toEqual(result1);
   });
 };
-test.only = (name: string, input: string, options: Options = {}) => {
+test.only = (
+  name: string,
+  input: string,
+  options: Partial<StringifyOptions> = {}
+) => {
   it.only(name, () => {
     const result = process(input, options);
     expect(result).toMatchSnapshot();

--- a/packages/uniorg-stringify/src/stringify.spec.ts
+++ b/packages/uniorg-stringify/src/stringify.spec.ts
@@ -1,41 +1,41 @@
 import { parse } from 'uniorg-parse/lib/parser';
 
-import { stringify } from './stringify';
+import { Options, stringify } from './stringify';
 
-const process = (input: string) => {
-  return stringify(parse(input));
+const process = (input: string, options: Options) => {
+  return stringify(parse(input), options);
 };
 
-const test = (name: string, input: string) => {
+const test = (name: string, input: string, options: Options = {}) => {
   it(name, () => {
-    const result = process(input);
+    const result = process(input, options);
     expect(result).toMatchSnapshot();
   });
   it(name + ' (second pass)', () => {
-    const result1 = process(input);
-    const result2 = process(result1);
+    const result1 = process(input, options);
+    const result2 = process(result1, options);
     expect(result2).toEqual(result1);
   });
 };
-test.skip = (name: string, input: string) => {
+test.skip = (name: string, input: string, options: Options = {}) => {
   it.skip(name, () => {
-    const result = process(input);
+    const result = process(input, options);
     expect(result).toMatchSnapshot();
   });
   it.skip(name + ' (second pass)', () => {
-    const result1 = process(input);
-    const result2 = process(result1);
+    const result1 = process(input, options);
+    const result2 = process(result1, options);
     expect(result2).toEqual(result1);
   });
 };
-test.only = (name: string, input: string) => {
+test.only = (name: string, input: string, options: Options = {}) => {
   it.only(name, () => {
-    const result = process(input);
+    const result = process(input, options);
     expect(result).toMatchSnapshot();
   });
   it.only(name + ' (second pass)', () => {
-    const result1 = process(input);
-    const result2 = process(result1);
+    const result1 = process(input, options);
+    const result2 = process(result1, options);
     expect(result2).toEqual(result1);
   });
 };
@@ -65,6 +65,27 @@ second paragraph`
 * level 1
 *** level 3`
     );
+    test(
+      'nested simple headlines separated by new-lines',
+      `* level 1
+
+** level 2
+
+*** level 3
+
+**** level 4`,
+      {
+        handlers: {
+          headline: (org, options) => {
+            const components = [
+              '*'.repeat(org.level),
+              stringify(org.children, options),
+            ].filter((x) => x !== null);
+            return `${components.join(' ')}\n\n`;
+          },
+        },
+      }
+    );
 
     test('statistics cookie', `* [115%]  headline`);
   });
@@ -87,6 +108,29 @@ CLOSED: SCHEDULED: [2021-05-31 Mon]
 :PROPERTIES:
 :CREATED: [2019-03-13 Wed 23:57]
 :END:`
+  );
+  test(
+    'property drawer forced to lower-case',
+    `* headline
+:PROPERTIES:
+:CREATED: [2019-03-13 Wed 23:57]
+:END:`,
+    {
+      handlers: {
+        'property-drawer': (org, options) => {
+          return (
+            [
+              ':properties:\n',
+              ...org.children.map((c) => stringify(c, options)),
+              ':end:',
+            ].join('') + `\n`
+          );
+        },
+        'node-property': (org) => {
+          return [':', org.key.toLowerCase(), ': ', org.value].join('') + '\n';
+        },
+      },
+    }
   );
   test(
     'file property drawer',
@@ -350,6 +394,13 @@ footnote
 
   describe('emphasis marks', () => {
     test('bold', '*hello*');
+    test('bold with custom char', '*hello*', {
+      handlers: {
+        bold: (org, options) => {
+          return `$${stringify(org.children, options)}$`;
+        },
+      },
+    });
     test('emphasis', `/Consider/ ~t*h*e~ *following* =example= +strike+`);
     test('underline', `_hello_`);
   });

--- a/packages/uniorg-stringify/src/stringify.ts
+++ b/packages/uniorg-stringify/src/stringify.ts
@@ -12,14 +12,17 @@ export type Handlers = {
 };
 
 export type StringifyOptions = {
-  handlers: Handlers
-}
+  handlers: Handlers;
+};
 
-export type Options = Partial<StringifyOptions>
+export type Options = Partial<StringifyOptions>;
 
-export function stringify(org: string | Node | Node[], options: Options = {}): string {
+export function stringify(
+  org: string | Node | Node[],
+  options: Options = {}
+): string {
   const result = Array.isArray(org)
-    ? org.map(o => stringify(o, options)).join('')
+    ? org.map((o) => stringify(o, options)).join('')
     : stringifyOne(org, options);
   return result;
 }
@@ -34,7 +37,9 @@ function stringifyOne(node: Node | string, options: Options): string {
   const result: string[] = [];
 
   if (org.affiliated) {
-    result.push(stringifyAffiliated(org.affiliated as AffiliatedKeywords, options));
+    result.push(
+      stringifyAffiliated(org.affiliated as AffiliatedKeywords, options)
+    );
   }
 
   result.push(stringifyNode(org, options));
@@ -71,7 +76,9 @@ function stringifyNode(org: OrgNode, options: Options): string {
       return withNewline(
         [
           org.closed ? `CLOSED: ${stringify(org.closed, options)}` : null,
-          org.scheduled ? `SCHEDULED: ${stringify(org.scheduled, options)}` : null,
+          org.scheduled
+            ? `SCHEDULED: ${stringify(org.scheduled, options)}`
+            : null,
           org.deadline ? `DEADLINE: ${stringify(org.deadline, options)}` : null,
         ]
           .filter((x) => x !== null)
@@ -79,7 +86,11 @@ function stringifyNode(org: OrgNode, options: Options): string {
       );
     case 'property-drawer':
       return withNewline(
-        [':PROPERTIES:\n', ...org.children.map(c => stringify(c, options)), ':END:'].join('')
+        [
+          ':PROPERTIES:\n',
+          ...org.children.map((c) => stringify(c, options)),
+          ':END:',
+        ].join('')
       );
     case 'node-property':
       return withNewline([':', org.key, ': ', org.value].join(''));
@@ -118,17 +129,24 @@ function stringifyNode(org: OrgNode, options: Options): string {
       );
     case 'list-item-tag':
       return `${stringify(org.children[0], options)} :: ${stringify(
-        org.children.slice(1), options
+        org.children.slice(1),
+        options
       )}`;
     case 'table':
       const value =
-        org.tableType === 'table.el' ? org.value : stringify(org.children, options);
+        org.tableType === 'table.el'
+          ? org.value
+          : stringify(org.children, options);
       return (
         withNewline(value) + (org.tblfm ? '#+TBLFM: ' + org.tblfm + '\n' : '')
       );
     case 'table-row':
       if (org.rowType === 'standard') {
-        return '| ' + org.children.map(c => stringify(c, options)).join(' | ') + ' |\n';
+        return (
+          '| ' +
+          org.children.map((c) => stringify(c, options)).join(' | ') +
+          ' |\n'
+        );
       } else {
         return '|-|\n';
       }
@@ -163,12 +181,16 @@ function stringifyNode(org: OrgNode, options: Options): string {
     case 'horizontal-rule':
       return withNewline('-----');
     case 'footnote-definition':
-      return withNewline(`[fn:${org.label}] ${stringify(org.children, options)}`);
+      return withNewline(
+        `[fn:${org.label}] ${stringify(org.children, options)}`
+      );
     case 'footnote-reference':
       return [
         '[fn:',
         org.label,
-        org.footnoteType === 'inline' ? ':' + stringify(org.children, options) : null,
+        org.footnoteType === 'inline'
+          ? ':' + stringify(org.children, options)
+          : null,
         ']',
       ]
         .filter((x) => x !== null)
@@ -251,7 +273,7 @@ function stringifyNode(org: OrgNode, options: Options): string {
         '[cite',
         org.style ? '/' + org.style : '',
         ':',
-        ...org.children.map(c => stringifyNode(c, options)).join(';'),
+        ...org.children.map((c) => stringifyNode(c, options)).join(';'),
         ']',
       ].join('');
     case 'citation-common-prefix':
@@ -259,7 +281,7 @@ function stringifyNode(org: OrgNode, options: Options): string {
     case 'citation-reference':
     case 'citation-prefix':
     case 'citation-suffix':
-      return org.children.map(c => stringifyNode(c, options)).join('');
+      return org.children.map((c) => stringifyNode(c, options)).join('');
     case 'citation-key':
       return '@' + org.key;
 
@@ -268,7 +290,9 @@ function stringifyNode(org: OrgNode, options: Options): string {
         ? org.rawLink
         : org.format === 'bracket'
           ? `[[${org.rawLink}]${
-              org.children.length ? '[' + stringify(org.children, options) + ']' : ''
+              org.children.length
+                ? '[' + stringify(org.children, options) + ']'
+                : ''
             }]`
           : `<${org.rawLink}>`;
     case 'superscript':
@@ -300,7 +324,10 @@ function stringifyNode(org: OrgNode, options: Options): string {
   }
 }
 
-function stringifyAffiliated(keywords: AffiliatedKeywords, options: Options): string {
+function stringifyAffiliated(
+  keywords: AffiliatedKeywords,
+  options: Options
+): string {
   return Object.entries(keywords)
     .map(([key, values]) => {
       const dualKeyword = Array.isArray(values) ? values[1] : null;

--- a/packages/uniorg-stringify/src/stringify.ts
+++ b/packages/uniorg-stringify/src/stringify.ts
@@ -5,7 +5,7 @@ import type {
 } from 'uniorg';
 import type { Node } from 'unist';
 
-type Handler<T> = (org: T, options: StringifyOptions) => string;
+type Handler<T> = (org: T, options: StringifyOptions) => string | null;
 
 export type Handlers = {
   [K in OrgNode['type']]?: Handler<OrgNode & { type: K }>;
@@ -68,7 +68,9 @@ function stringifyNode(org: OrgNode, options: StringifyOptions): string {
   const handler = options.handlers?.[org.type];
   if (handler) {
     const rendered = (handler as any)(org, options);
-    if (rendered) return rendered;
+    if (rendered !== null && rendered !== undefined) {
+      return rendered;
+    }
   }
 
   switch (org.type) {


### PR DESCRIPTION
Hi @rasendubi 

This PR is a follow-up to the discussions we had last year in https://github.com/rasendubi/uniorg/issues/72 about letting the user having more controls about the final output.

I followed your advice and imitated what's already existing with `uniorg2rehype`. Therefore, `uniorgStringify` can now accept an optional `handlers` configuration.

I've added 3 tests to illustrate various situations and also a short documentation in the README.

Don't hesitate to tell me if something is missing. Thanks.