### PR TITLE
fix(orgx): include types in published package

### DIFF
--- a/.changeset/funny-sloths-perform.md
+++ b/.changeset/funny-sloths-perform.md
@@ -1,0 +1,7 @@
+---
+"@uniorgjs/orgx": patch
+---
+
+Include types in published package
+
+@uniorgjs/orgx was missing its type declarations when publishing. Include them properly.


### PR DESCRIPTION
`@uniorgjs/orgx` from NPM seems to be missing it's built type declarations. I think this is because the types are included in the package's `.gitignore` so they don't get committed, but unfortunately `pnpm publish` also uses the `.gitignore` to determine what files get included in the published package, leading to the types not getting distributed.

This PR should fix the problem by including an empty `.npmignore`, which will override the `.gitignore` file during publish and include the types in published packages again ([docs](https://docs.npmjs.com/cli/v8/commands/npm-publish#files-included-in-package)).