### PR TITLE
fix(#148): fix parser skipping final newlines after objects

### DIFF
--- a/.changeset/clever-mammals-clap.md
+++ b/.changeset/clever-mammals-clap.md
@@ -1,0 +1,5 @@
+---
+'uniorg-parse': patch
+---
+
+Fix parser erroneously adding newlines to affiliated keywords

--- a/.changeset/large-melons-dance.md
+++ b/.changeset/large-melons-dance.md
@@ -1,0 +1,5 @@
+---
+'uniorg-parse': patch
+---
+
+Fix parser skipping final newlines in paragraphs after other objects.

--- a/packages/uniorg-attach/src/__snapshots__/index.spec.ts.snap
+++ b/packages/uniorg-attach/src/__snapshots__/index.spec.ts.snap
@@ -53,6 +53,8 @@ children:
         rawLink: "file:/home/user/data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         path: "/home/user/data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         children: []
+      - type: "text"
+        value: "\\n"
 `;
 
 exports[`uniorg-attach > options > idDir > idDir overrides default id directory 1`] = `
@@ -78,6 +80,8 @@ children:
         rawLink: "file:attachments/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         path: "attachments/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         children: []
+      - type: "text"
+        value: "\\n"
 `;
 
 exports[`uniorg-attach > options > idToPath > idTsFolderFormat is better suited for timestamp ids 1`] = `
@@ -103,6 +107,8 @@ children:
         rawLink: "file:data/202109/22T144052.487159/file.txt"
         path: "data/202109/22T144052.487159/file.txt"
         children: []
+      - type: "text"
+        value: "\\n"
 `;
 
 exports[`uniorg-attach > options > useInheritance > DIR takes precedence even it it’s defined higher up 1`] = `
@@ -151,6 +157,8 @@ children:
             rawLink: "file:attach/text.txt"
             path: "attach/text.txt"
             children: []
+          - type: "text"
+            value: "\\n"
 `;
 
 exports[`uniorg-attach > options > useInheritance > useInheritance allows looking up DIR 1`] = `
@@ -192,6 +200,8 @@ children:
             rawLink: "file:attach/text.txt"
             path: "attach/text.txt"
             children: []
+          - type: "text"
+            value: "\\n"
 `;
 
 exports[`uniorg-attach > options > useInheritance > useInheritance allows looking up ID 1`] = `
@@ -233,6 +243,8 @@ children:
             rawLink: "file:data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/text.txt"
             path: "data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/text.txt"
             children: []
+          - type: "text"
+            value: "\\n"
 `;
 
 exports[`uniorg-attach > with DIR set > DIR has higher precedence than ID 1`] = `
@@ -361,6 +373,8 @@ children:
         rawLink: "file:data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         path: "data/ea/d7b7db-8aac-4b1f-893f-9e7f5ca6ea2c/hello.txt"
         children: []
+      - type: "text"
+        value: "\\n"
 `;
 
 exports[`uniorg-attach > without ID or DIR set > inside headline 1`] = `

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -59,7 +59,7 @@ children:
       NAME: "name"
       CAPTION:
         - - type: "text"
-            value: "hi\\n"
+            value: "hi"
     contentsBegin: 27
     contentsEnd: 36
     children:
@@ -77,9 +77,9 @@ children:
       NAME: "name2"
       CAPTION:
         - - type: "text"
-            value: "caption1\\n"
+            value: "caption1"
         - - type: "text"
-            value: "caption2\\n"
+            value: "caption2"
     contentsBegin: 69
     contentsEnd: 78
     children:
@@ -1064,6 +1064,8 @@ children:
             children:
               - type: "text"
                 value: "there"
+          - type: "text"
+            value: "\\n"
 `;
 
 exports[`org/parser > diary sexp 1`] = `
@@ -3219,6 +3221,8 @@ children:
                 children:
                   - type: "text"
                     value: "ANOTHER ALTERNATIVE"
+              - type: "text"
+                value: "\\n"
       - type: "list-item"
         indent: 0
         bullet: "- "
@@ -3254,6 +3258,8 @@ children:
                     children:
                       - type: "text"
                         value: "The ultimate Git solution for privacy-oriented individuals!"
+              - type: "text"
+                value: "\\n"
 `;
 
 exports[`org/parser > list > list after paragraph 1`] = `
@@ -3690,6 +3696,8 @@ children:
             children:
               - type: "text"
                 value: "there"
+          - type: "text"
+            value: "\\n"
 `;
 
 exports[`org/parser > lowercase property drawer 1`] = `
@@ -4042,6 +4050,33 @@ children:
         children:
           - type: "text"
             value: "2"
+`;
+
+exports[`org/parser > paragraph end after link (#148) 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 24
+children:
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 0
+    contentsEnd: 9
+    children:
+      - type: "link"
+        format: "bracket"
+        linkType: "fuzzy"
+        rawLink: "link"
+        path: "link"
+        children: []
+      - type: "text"
+        value: "\\n"
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 10
+    contentsEnd: 24
+    children:
+      - type: "text"
+        value: "next paragraph"
 `;
 
 exports[`org/parser > paragraph split by empty line 1`] = `

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -172,6 +172,13 @@ a2
 b`
   );
 
+  itParses(
+    'paragraph end after link (#148)',
+    `[[link]]
+
+next paragraph`
+  );
+
   itParses('keyword', `#+title: hi`);
 
   itParses('fake keyword', `#+ title: hi`);

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -492,7 +492,8 @@ class Parser {
     // handle text after the last object
     const text = this.r.rest();
     this.r.advance(text.length);
-    if (text.trim().length) {
+    // skip whitespace-only text
+    if (!text.match(/^[ \t]*$/)) {
       objects.push(
         u('text', this.addPosition({ value: text }, prevEnd, this.r.offset()))
       );
@@ -1110,7 +1111,10 @@ class Parser {
       const isParsed = parsedKeywords.has(keyword);
 
       this.r.advance(keywordM);
-      this.r.narrow(this.r.offset(), this.r.offset() + this.r.line().length);
+      this.r.narrow(
+        this.r.offset(),
+        this.r.offset() + this.r.line().length - 1 /* don't include newline */
+      );
       const mainValue = isParsed
         ? this.parseObjects(restrictionFor('keyword'))
         : this.r.rest().trim();


### PR DESCRIPTION
Org omits whitespace-only text objects at the end of paragraph. However, this only concerns spaces and tabs, not newlines. We incorrect used `.trim()` to test for whitespace-only, while lead to newline-only text object being skipped.

Use regex matching to test if final text is whitespace-only.

This made affiliated keyword parsing unintentionally capture newlines when org parser does not. Fix that by trimming newlines from affiliated keywoard contents before parsing.