### PR TITLE
fix(uniorg-parse): match `[[..]]` link type with `^`

### DIFF
--- a/.changeset/quiet-rooms-clap.md
+++ b/.changeset/quiet-rooms-clap.md
@@ -1,0 +1,7 @@
+---
+"uniorg-parse": patch
+---
+
+Fix link type detection in `[[ ]]` links when protocol name occurs in the middle of the URL.
+
+Previously, `[[my-link:https://blah]]` was incorrectly detected as `https` link type. Now it's correctly recognized as `fuzzy` link type.

--- a/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
+++ b/packages/uniorg-parse/src/__snapshots__/parser.spec.ts.snap
@@ -2549,6 +2549,24 @@ children:
         children: []
 `;
 
+exports[`org/parser > links > custom type wrapping a url 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 28
+children:
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 0
+    contentsEnd: 28
+    children:
+      - type: "link"
+        format: "bracket"
+        linkType: "fuzzy"
+        rawLink: "card:https://example.com"
+        path: "card:https://example.com"
+        children: []
+`;
+
 exports[`org/parser > links > file link with percents 1`] = `
 type: "org-data"
 contentsBegin: 0
@@ -2600,6 +2618,24 @@ children:
         linkType: "https"
         rawLink: "https://example.com/hello"
         path: "//example.com/hello"
+        children: []
+`;
+
+exports[`org/parser > links > leading whitespace is not a link type 1`] = `
+type: "org-data"
+contentsBegin: 0
+contentsEnd: 24
+children:
+  - type: "paragraph"
+    affiliated: {}
+    contentsBegin: 0
+    contentsEnd: 24
+    children:
+      - type: "link"
+        format: "bracket"
+        linkType: "fuzzy"
+        rawLink: " https://example.com"
+        path: " https://example.com"
         children: []
 `;
 

--- a/packages/uniorg-parse/src/parser.spec.ts
+++ b/packages/uniorg-parse/src/parser.spec.ts
@@ -480,6 +480,10 @@ I have no :END:`
 
     itParses('https link', `[[https://example.com/hello]]`);
 
+    itParses('custom type wrapping a url', `[[card:https://example.com]]`);
+
+    itParses('leading whitespace is not a link type', `[[ https://example.com]]`);
+
     itParses(
       'multiline description',
       `[[www.something.com][line1

--- a/packages/uniorg-parse/src/parser.ts
+++ b/packages/uniorg-parse/src/parser.ts
@@ -2351,7 +2351,7 @@ class Parser {
       return { linkType: 'file', path: link };
     }
     // Explicit type (http, irc, bbdb...).
-    const m = link.match(new RegExp(this.re.linkTypesRe()));
+    const m = link.match(new RegExp(`^${this.re.linkTypesRe()}`));
     if (m) {
       return { linkType: m[1], path: link.slice(m[0].length) };
     }


### PR DESCRIPTION
- Resolves: https://github.com/rasendubi/uniorg/issues/152
